### PR TITLE
Remove erroneous `psycopg2` import error when user does not need `pos…

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.15
+current_version = 0.1.16
 commit = False
 tag = False
 allow_dirty = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ author = 'Omar Khan'
 # The short X.Y version
 version = '0.1'
 # The full version, including alpha/beta/rc tags
-release = '0.1.15'
+release = '0.1.16'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SETUP_REQUIREMENTS = [
 
 setup(
     name='pytest-mock-resources',
-    version='0.1.15',
+    version='0.1.16',
     url='https://github.com/schireson/schireson-pytest-mock-resources',
     author_email='omar@schireson.com',
     author='Omar Khan',

--- a/src/pytest_mock_resources/container/postgres.py
+++ b/src/pytest_mock_resources/container/postgres.py
@@ -1,6 +1,5 @@
-import psycopg2
 import pytest
-from sqlalchemy import create_engine
+import sqlalchemy
 
 from pytest_mock_resources.container import ContainerCheckFailed, get_container_fn, HOST, IN_CI
 
@@ -15,18 +14,8 @@ config = {
 }
 
 
-def get_psycopg2_connection(database_name):
-    return psycopg2.connect(
-        dbname=database_name,
-        user=config["username"],
-        password=config["password"],
-        host=config["host"],
-        port=str(config["port"]),
-    )
-
-
 def get_sqlalchemy_engine(database_name):
-    engine = create_engine(
+    engine = sqlalchemy.create_engine(
         "postgresql://{username}:{password}@{host}:{port}/{database}?sslmode=disable".format(
             database=database_name,
             username=config["username"],
@@ -45,8 +34,8 @@ def get_sqlalchemy_engine(database_name):
 
 def check_postgres_fn():
     try:
-        get_psycopg2_connection(config["root_database"])
-    except psycopg2.OperationalError:
+        get_sqlalchemy_engine(config["root_database"])
+    except sqlalchemy.exc.OperationalError:
         raise ContainerCheckFailed(
             "Unable to connect to a presumed Postgres test container via given config: {}".format(
                 config


### PR DESCRIPTION
…tgres` fixtures.