### PR TITLE
Allow decimal (numeric) columns in sqlite without warning.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.6.0
 commit = False
 tag = False
 allow_dirty = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Omar Khan'
 # The short X.Y version
 version = '0.1'
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = '0.6.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ SETUP_REQUIREMENTS = ["pytest-runner"]
 
 setup(
     name="pytest-mock-resources",
-    version="0.5.0",
+    version="0.6.0",
     url="https://github.com/schireson/schireson-pytest-mock-resources",
     author_email="omar@schireson.com",
     author="Omar Khan",


### PR DESCRIPTION
Fixes #33 