### PR TITLE
Fix a bug where pytest markers are only created for postgres

### DIFF
--- a/src/pytest_mock_resources/hooks.py
+++ b/src/pytest_mock_resources/hooks.py
@@ -6,7 +6,7 @@ def pytest_configure(config):
     for resource_kind in _resource_kinds:
         config.addinivalue_line(
             "markers",
-            "postgres: Tests which make use of {kind} fixtures".format(kind=resource_kind),
+            "{kind}: Tests which make use of {kind} fixtures".format(kind=resource_kind),
         )
 
 


### PR DESCRIPTION
It leads to this warning all the time, which is kind of annoying:
```
====================================================== warnings summary =======================================================
.venv/lib/python3.8/site-packages/_pytest/nodes.py:274
  /***/.venv/lib/python3.8/site-packages/_pytest/nodes.py:274: PytestUnknownMarkWar//docs.pytest.org/en/stable/mark.html
    marker_ = getattr(MARK_GEN, marker)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================ 3 passed, 1 warning in 5.74s =================================================
```