### PR TITLE
feat: Add configurable template option for postgres database creation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ test: test-parallel
 
 ## Lint
 lint:
-	flake8 src tests
-	isort --check-only --diff src tests
-	pydocstyle src tests
-	black --check src tests
-	mypy src tests
+	flake8 src tests || exit 1
+	isort --check-only --diff src tests || exit 1
+	pydocstyle src tests || exit 1
+	black --check src tests || exit 1
+	mypy src tests || exit 1
 
 format:
 	isort --recursive src tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -766,6 +766,17 @@ mypy = ">=0.790"
 typing-extensions = ">=3.7.4"
 
 [[package]]
+name = "sqlalchemy2-stubs"
+version = "0.0.2a19"
+description = "Typing Stubs for SQLAlchemy 1.4"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "sqlparse"
 version = "0.4.2"
 description = "A non-validating SQL parser."
@@ -900,7 +911,7 @@ redshift = ["boto3", "moto", "sqlparse"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6, <4"
-content-hash = "0baf43f0b4eacbe5892ffaae4f268f315b23d7174edc64c66eb9563f418f1a50"
+content-hash = "b44ccf91f31a7b2f82e6ee638a010ea1462daa2916439c9f3932d9c0bfa88a8f"
 
 [metadata.files]
 appdirs = [
@@ -1191,12 +1202,28 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1205,14 +1232,27 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1222,6 +1262,12 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1490,6 +1536,11 @@ regex = [
     {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
     {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
     {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e"},
+    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b"},
     {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
     {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
     {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
@@ -1499,6 +1550,11 @@ regex = [
     {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
     {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
     {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a"},
+    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00"},
     {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
     {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
     {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
@@ -1508,6 +1564,11 @@ regex = [
     {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
     {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
     {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942"},
+    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a"},
     {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
     {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
     {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
@@ -1518,6 +1579,11 @@ regex = [
     {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
     {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
     {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf"},
+    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0"},
     {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
     {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
     {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
@@ -1528,6 +1594,11 @@ regex = [
     {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
     {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
     {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737"},
+    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d"},
     {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
     {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
     {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
@@ -1593,6 +1664,10 @@ sqlalchemy = [
 sqlalchemy-stubs = [
     {file = "sqlalchemy-stubs-0.4.tar.gz", hash = "sha256:c665d6dd4482ef642f01027fa06c3d5e91befabb219dc71fc2a09e7d7695f7ae"},
     {file = "sqlalchemy_stubs-0.4-py3-none-any.whl", hash = "sha256:5eec7aa110adf9b957b631799a72fef396b23ff99fe296df726645d01e312aa5"},
+]
+sqlalchemy2-stubs = [
+    {file = "sqlalchemy2-stubs-0.0.2a19.tar.gz", hash = "sha256:2117c48ce5acfe33bf9c9bfce2a981632d931949e68fa313aa5c2a3bc980ca7a"},
+    {file = "sqlalchemy2_stubs-0.0.2a19-py3-none-any.whl", hash = "sha256:aac7dca77a2c49e5f0934976421d5e25ae4dc5e27db48c01e055f81caa1e3ead"},
 ]
 sqlparse = [
     {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ pytest-asyncio = "^0.15.1"
 types-six = "^1.16.0"
 types-PyMySQL = "^1.0.2"
 types-redis = "^3.5.6"
+sqlalchemy2-stubs = "^0.0.2-alpha.19"
 
 [tool.poetry.extras]
 postgres = ['psycopg2']
@@ -86,6 +87,13 @@ use_parentheses = true
 
 [tool.black]
 line_length = 100
+
+[tool.mypy]
+strict_optional = true
+ignore_missing_imports = true
+warn_unused_ignores = true
+incremental = true
+plugins = 'sqlalchemy.ext.mypy.plugin'
 
 [build-system]
 requires = ["poetry_core==1.0.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.1.9"
+version = "2.1.10"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/cli.py
+++ b/src/pytest_mock_resources/cli.py
@@ -2,7 +2,7 @@ import argparse
 import enum
 import subprocess  # nosec
 
-from pytest_mock_resources import PostgresConfig, MysqlConfig, MongoConfig
+from pytest_mock_resources import MongoConfig, MysqlConfig, PostgresConfig
 
 postgres_image = PostgresConfig().image
 mysql_image = MysqlConfig().image

--- a/src/pytest_mock_resources/compat/sqlalchemy.py
+++ b/src/pytest_mock_resources/compat/sqlalchemy.py
@@ -3,9 +3,9 @@ import sqlalchemy.engine.url
 from pytest_mock_resources.compat.import_ import ImportAdaptor
 
 try:
-    from sqlalchemy.ext import asyncio  # type: ignore
+    from sqlalchemy.ext import asyncio
 except ImportError:
-    asyncio = ImportAdaptor(
+    asyncio = ImportAdaptor(  # type: ignore
         "SQLAlchemy",
         "SQLAlchemy >= 1.4",
         fail_message="Cannot use sqlalchemy async features with SQLAlchemy < 1.4.\n",

--- a/src/pytest_mock_resources/fixture/database/mongo.py
+++ b/src/pytest_mock_resources/fixture/database/mongo.py
@@ -53,7 +53,9 @@ def _create_clean_database(config):
     new_database.command("createUser", db_id, pwd=password, roles=["dbOwner"])
 
     #  pass back an authenticated db connection
-    limited_client = pymongo.MongoClient(config.host, config.port, username=db_id, password=password, authSource=db_id)
+    limited_client = pymongo.MongoClient(
+        config.host, config.port, username=db_id, password=password, authSource=db_id
+    )
     limited_db = limited_client[db_id]
 
     assign_fixture_credentials(

--- a/src/pytest_mock_resources/fixture/database/redis.py
+++ b/src/pytest_mock_resources/fixture/database/redis.py
@@ -46,13 +46,15 @@ def create_redis_fixture(scope="function"):
     @pytest.fixture(scope=scope)
     def _(request, _redis_container, pmr_redis_config):
         database_number = 0
-        if hasattr(request.config, 'workerinput'):
+        if hasattr(request.config, "workerinput"):
             worker_input = request.config.workerinput
-            worker_id = worker_input['workerid']  # For example "gw0".
+            worker_id = worker_input["workerid"]  # For example "gw0".
             database_number = int(worker_id[2:])
 
         if database_number >= 16:
-            raise ValueError("The redis fixture currently only supports up to 16 parallel executions")
+            raise ValueError(
+                "The redis fixture currently only supports up to 16 parallel executions"
+            )
 
         db = redis.Redis(host=pmr_redis_config.host, port=pmr_redis_config.port, db=database_number)
         db.flushdb()

--- a/src/pytest_mock_resources/fixture/database/relational/postgresql.py
+++ b/src/pytest_mock_resources/fixture/database/relational/postgresql.py
@@ -18,8 +18,10 @@ def pmr_postgres_config():
     return PostgresConfig()
 
 
-def create_engine_manager(pmr_postgres_config, ordered_actions, tables):
-    database_name = _create_clean_database(pmr_postgres_config)
+def create_engine_manager(
+    pmr_postgres_config, ordered_actions, tables, createdb_template="template1"
+):
+    database_name = _create_clean_database(pmr_postgres_config, createdb_template=createdb_template)
     engine = get_sqlalchemy_engine(pmr_postgres_config, database_name)
     assign_fixture_credentials(
         engine,
@@ -34,7 +36,12 @@ def create_engine_manager(pmr_postgres_config, ordered_actions, tables):
 
 
 def create_postgres_fixture(
-    *ordered_actions, scope="function", tables=None, session=None, async_=False
+    *ordered_actions,
+    scope="function",
+    tables=None,
+    session=None,
+    async_=False,
+    createdb_template="template1"
 ):
     """Produce a Postgres fixture.
 
@@ -49,16 +56,23 @@ def create_postgres_fixture(
         session: Whether to return a session instead of an engine directly. This can
             either be a bool or a callable capable of producing a session.
         async_: Whether to return an async fixture/client.
+        createdb_template: The template database used to create sub-databases. "template1" is the
+            default chosen when no template is specified.
     """
+    engine_manager_kwargs = dict(
+        ordered_actions=ordered_actions,
+        tables=tables,
+        createdb_template=createdb_template,
+    )
 
     @pytest.fixture(scope=scope)
     def _sync(_postgres_container, pmr_postgres_config):
-        engine_manager = create_engine_manager(pmr_postgres_config, ordered_actions, tables)
+        engine_manager = create_engine_manager(pmr_postgres_config, **engine_manager_kwargs)
         yield from engine_manager.manage_sync(session=session)
 
     @pytest.fixture(scope=scope)
     async def _async(_postgres_container, pmr_postgres_config):
-        engine_manager = create_engine_manager(pmr_postgres_config, ordered_actions, tables)
+        engine_manager = create_engine_manager(pmr_postgres_config, **engine_manager_kwargs)
         async for engine in engine_manager.manage_async(session=session):
             yield engine
 
@@ -68,7 +82,7 @@ def create_postgres_fixture(
         return _sync
 
 
-def _create_clean_database(config):
+def _create_clean_database(config, createdb_template="template1"):
     root_engine = get_sqlalchemy_engine(config, config.root_database, isolation_level="AUTOCOMMIT")
 
     try:
@@ -93,7 +107,7 @@ def _create_clean_database(config):
     id_ = tuple(result)[0][0]
     database_name = "pytest_mock_resource_db_{}".format(id_)
 
-    root_engine.execute('CREATE DATABASE "{}"'.format(database_name))
+    root_engine.execute('CREATE DATABASE "{}" template={}'.format(database_name, createdb_template))
     root_engine.execute(
         'GRANT ALL PRIVILEGES ON DATABASE "{}" TO CURRENT_USER'.format(database_name)
     )

--- a/src/pytest_mock_resources/fixture/database/relational/redshift/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/relational/redshift/__init__.py
@@ -3,8 +3,8 @@ import pytest
 from pytest_mock_resources.fixture.database.generic import assign_fixture_credentials
 from pytest_mock_resources.fixture.database.relational.generic import EngineManager
 from pytest_mock_resources.fixture.database.relational.postgresql import (
-    _create_clean_database,
     get_sqlalchemy_engine,
+    produce_clean_database,
 )
 from pytest_mock_resources.patch.redshift import psycopg2, sqlalchemy
 
@@ -30,7 +30,7 @@ def create_redshift_fixture(*ordered_actions, scope="function", tables=None, ses
 
     @pytest.fixture(scope=scope)
     def _(_redshift_container, pmr_postgres_config):
-        database_name = _create_clean_database(pmr_postgres_config)
+        database_name = produce_clean_database(pmr_postgres_config)
         engine = get_sqlalchemy_engine(pmr_postgres_config, database_name)
 
         assign_fixture_credentials(

--- a/src/pytest_mock_resources/fixture/database/relational/sqlite.py
+++ b/src/pytest_mock_resources/fixture/database/relational/sqlite.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 from sqlalchemy import create_engine, event
-from sqlalchemy.dialects import registry
+from sqlalchemy.dialects import registry  # type: ignore
 from sqlalchemy.dialects.postgresql import JSON, JSONB
 from sqlalchemy.dialects.sqlite import base as sqlite_base
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite

--- a/tests/examples/test_multiprocess_redis_database/test_split.py
+++ b/tests/examples/test_multiprocess_redis_database/test_split.py
@@ -10,8 +10,6 @@ tests.
 A correct implementation would use some mechanism to avoid this inter-parallel-test
 key conflict problem.
 """
-# import random
-# import time
 
 
 def test_node_one(redis, pytestconfig):

--- a/tests/examples/test_multiprocess_redis_database/test_split.py
+++ b/tests/examples/test_multiprocess_redis_database/test_split.py
@@ -10,8 +10,8 @@ tests.
 A correct implementation would use some mechanism to avoid this inter-parallel-test
 key conflict problem.
 """
-import random
-import time
+# import random
+# import time
 
 
 def test_node_one(redis, pytestconfig):
@@ -31,8 +31,8 @@ def test_node_four(redis, pytestconfig):
 
 
 def run_test(redis, pytestconfig):
-    worker_id = int(pytestconfig.workerinput['workerid'][2:])
-    database = redis.connection_pool.get_connection('set').db
+    worker_id = int(pytestconfig.workerinput["workerid"][2:])
+    database = redis.connection_pool.get_connection("set").db
     assert worker_id == database
     print(worker_id, database)
 
@@ -41,7 +41,7 @@ def run_test(redis, pytestconfig):
     # XXX: however until the plugin is overall more process-safe, it's too flaky.
     # time.sleep(random.randrange(1, 10) / 10)
     value = redis.get("foo")
-    
+
     assert value == b"bar"
 
     redis.flushdb()

--- a/tests/fixture/database/__init__.py
+++ b/tests/fixture/database/__init__.py
@@ -1,9 +1,10 @@
 import random
 
+from sqlalchemy import create_engine
+
 from pytest_mock_resources.compat import boto3, moto, psycopg2
 from pytest_mock_resources.patch.redshift.mock_s3_copy import read_data_csv
 from pytest_mock_resources.patch.redshift.mock_s3_unload import get_data_csv
-from sqlalchemy import create_engine
 
 original_data = [
     (3342, 32434.0, "a", "gfhsdgaf"),

--- a/tests/fixture/database/test_ordered_actions.py
+++ b/tests/fixture/database/test_ordered_actions.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 from sqlalchemy import Column, ForeignKey, Integer, String, text
 from sqlalchemy.exc import ProgrammingError
@@ -15,7 +17,8 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
-    objects = relationship("Object", back_populates="owner")
+
+    objects: List['Object'] = relationship("Object", back_populates="owner")
 
 
 class Object(Base):
@@ -25,7 +28,8 @@ class Object(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
     belongs_to = Column(Integer, ForeignKey("stuffs.user.id"))
-    owner = relationship("User", back_populates="objects")
+
+    owner: List[User] = relationship("User", back_populates="objects")
 
 
 rows = Rows(User(name="Harold"), User(name="Gump"))

--- a/tests/fixture/database/test_ordered_actions.py
+++ b/tests/fixture/database/test_ordered_actions.py
@@ -18,7 +18,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
 
-    objects: List['Object'] = relationship("Object", back_populates="owner")
+    objects: List["Object"] = relationship("Object", back_populates="owner")
 
 
 class Object(Base):

--- a/tests/fixture/database/test_postgres.py
+++ b/tests/fixture/database/test_postgres.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, Integer
+from sqlalchemy.ext.declarative import declarative_base
+
+from pytest_mock_resources import create_postgres_fixture
+
+Base = declarative_base()
+
+
+class Thing(Base):
+    __tablename__ = "thing"
+
+    id = Column(Integer, autoincrement=True, primary_key=True)
+
+
+createdb_template_pg = create_postgres_fixture(Base, createdb_template="template0", session=True)
+
+
+def test_createdb_template(createdb_template_pg):
+    """Assert successful usage of a fixture which sets the `createdb_template` argument."""
+    thing = Thing(id=1)
+    createdb_template_pg.add(thing)
+    createdb_template_pg.commit()

--- a/tests/fixture/database/test_postgres.py
+++ b/tests/fixture/database/test_postgres.py
@@ -1,7 +1,9 @@
-from sqlalchemy import Column, Integer
+from sqlalchemy import Column, event, Integer
 from sqlalchemy.ext.declarative import declarative_base
 
 from pytest_mock_resources import create_postgres_fixture
+from pytest_mock_resources.container.postgres import get_sqlalchemy_engine
+from pytest_mock_resources.fixture.database.relational.postgresql import _create_clean_database
 
 Base = declarative_base()
 
@@ -12,11 +14,33 @@ class Thing(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
 
 
-createdb_template_pg = create_postgres_fixture(Base, createdb_template="template0", session=True)
+createdb_template_pg = create_postgres_fixture(Base, createdb_template="template0")
+
+
+def test_create_clean_database_createdb_template(pmr_postgres_config, createdb_template_pg):
+    """Assert `createdb_template` is included in emitted CREATE DATABASE statement."""
+    root_engine = get_sqlalchemy_engine(
+        pmr_postgres_config, pmr_postgres_config.root_database, isolation_level="AUTOCOMMIT"
+    )
+
+    statement = ""
+
+    def before_execute(conn, clauseelement, multiparams, params, execution_options):
+        # Search for our create database statement, so we can assert against it.
+        if "CREATE DATABASE" in clauseelement:
+            nonlocal statement
+            statement = clauseelement
+        return clauseelement, multiparams, params
+
+    # Use the event system to hook into the statements being executed by sqlalchemy.
+    with root_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        event.listen(conn, "before_execute", before_execute)
+        _create_clean_database(conn, createdb_template="template0")
+        event.remove(conn, "before_execute", before_execute)
+
+    assert "template0" in statement
 
 
 def test_createdb_template(createdb_template_pg):
     """Assert successful usage of a fixture which sets the `createdb_template` argument."""
-    thing = Thing(id=1)
-    createdb_template_pg.add(thing)
-    createdb_template_pg.commit()
+    createdb_template_pg.execute(Thing.__table__.insert().values({"id": 1}))


### PR DESCRIPTION
Using the default template1 can cause issues if you're testing code which connects to template1. By enabling a configurable template, such tests can make use of template0 (or any other template).

Sidebar, theoretically postgres' template feature (we could create our own template database for example) could allow us to create a canonical template once (per fixture, say) and save the cost of creating large sets of tables or input data