### PR TITLE
feat: Refactor redshift fixture to be "first class".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Changelog
 
-## [Unreleased](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.1.12...HEAD) (2022-02-13)
+### [v2.2.3](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.2.2...v2.2.3) (2022-02-23)
+
+#### Features
+
+* Refactor redshift fixture to be "first class". 1a3076d
+
+
+### [v2.2.2](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.2.1...v2.2.2) (2022-02-23)
+
+
+### [v2.2.1](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.2.0...v2.2.1) (2022-02-22)
+
+
+## [v2.2.0](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.1.12...v2.2.0) (2022-02-14)
 
 ### Features
 
-* Perform container cleanup in a multiprocess safe way. 28db0fb
+* Perform container cleanup in a multiprocess safe way. 10a9946
 
 
 ### [v2.1.12](https://github.com/schireson/schireson-pytest-mock-resources/compare/v2.1.11...v2.1.12) (2022-02-08)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint:
 	mypy src tests || exit 1
 
 format:
-	isort --recursive src tests
+	isort src tests
 	black src tests
 
 ## Build
@@ -45,7 +45,7 @@ build-docs:
 	pip install -r docs/requirements.txt
 	make -C docs html
 
-build: build-package build-docs
+build: build-package
 
 publish: build
 	poetry publish -u __token__ -p '${PYPI_PASSWORD}' --no-interaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.2.2"
+version = "2.2.3"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/__init__.py
+++ b/src/pytest_mock_resources/__init__.py
@@ -2,15 +2,15 @@
 from pytest_mock_resources.container import (
     _mongo_container,
     _mysql_container,
-    _postgres_container,
     _redis_container,
-    _redshift_container,
     MongoConfig,
     MysqlConfig,
     PostgresConfig,
     RedisConfig,
 )
 from pytest_mock_resources.fixture.database import (
+    _postgres_container,
+    _redshift_container,
     create_mongo_fixture,
     create_mysql_fixture,
     create_postgres_fixture,
@@ -21,6 +21,7 @@ from pytest_mock_resources.fixture.database import (
     pmr_mysql_config,
     pmr_postgres_config,
     pmr_redis_config,
+    pmr_redshift_config,
     Rows,
     Statements,
 )

--- a/src/pytest_mock_resources/container/__init__.py
+++ b/src/pytest_mock_resources/container/__init__.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 from pytest_mock_resources.container.mongo import _mongo_container, MongoConfig
 from pytest_mock_resources.container.mysql import _mysql_container, MysqlConfig
-from pytest_mock_resources.container.postgres import _postgres_container, PostgresConfig
+from pytest_mock_resources.container.postgres import PostgresConfig
 from pytest_mock_resources.container.redis import _redis_container, RedisConfig
-from pytest_mock_resources.container.redshift import _redshift_container

--- a/src/pytest_mock_resources/container/redshift.py
+++ b/src/pytest_mock_resources/container/redshift.py
@@ -1,6 +1,60 @@
-import pytest
+import sqlalchemy
+
+from pytest_mock_resources.config import DockerContainerConfig, fallback
+from pytest_mock_resources.container.base import ContainerCheckFailed
+from pytest_mock_resources.container.postgres import get_sqlalchemy_engine
 
 
-@pytest.fixture(scope="session")
-def _redshift_container(_postgres_container):
-    return _postgres_container
+class RedshiftConfig(DockerContainerConfig):
+    """Define the configuration object for Redshift.
+
+    Args:
+        image (str): The docker image:tag specifier to use for Redshift containers.
+            Defaults to :code:`"postgres:9.6.10-alpine"`.
+        host (str): The hostname under which a mounted port will be available.
+            Defaults to :code:`"localhost"`.
+        port (int): The port to bind the container to.
+            Defaults to :code:`5532`.
+        ci_port (int): The port to bind the container to when a CI environment is detected.
+            Defaults to :code:`5432`.
+        username (str): The username of the root Redshift user
+            Defaults to :code:`"user"`.
+        password (str): The password of the root Redshift password
+            Defaults to :code:`"password"`.
+        root_database (str): The name of the root Redshift database to create.
+            Defaults to :code:`"dev"`.
+    """
+
+    name = "redshift"
+    _fields = {"image", "host", "port", "ci_port", "username", "password", "root_database"}
+    _fields_defaults = {
+        "image": "postgres:9.6.10-alpine",
+        "port": 5532,
+        "ci_port": 5432,
+        "username": "user",
+        "password": "password",
+        "root_database": "dev",
+    }
+
+    @fallback
+    def username(self):
+        raise NotImplementedError()
+
+    @fallback
+    def password(self):
+        raise NotImplementedError()
+
+    @fallback
+    def root_database(self):
+        raise NotImplementedError()
+
+
+def check_redshift_fn(config):
+    try:
+        get_sqlalchemy_engine(config, config.root_database)
+    except sqlalchemy.exc.OperationalError:
+        raise ContainerCheckFailed(
+            "Unable to connect to a presumed Redshift test container via given config: {}".format(
+                config
+            )
+        )

--- a/src/pytest_mock_resources/fixture/database/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/__init__.py
@@ -2,12 +2,15 @@
 from pytest_mock_resources.fixture.database.mongo import create_mongo_fixture, pmr_mongo_config
 from pytest_mock_resources.fixture.database.redis import create_redis_fixture, pmr_redis_config
 from pytest_mock_resources.fixture.database.relational import (
+    _postgres_container,
+    _redshift_container,
     create_mysql_fixture,
     create_postgres_fixture,
     create_redshift_fixture,
     create_sqlite_fixture,
     pmr_mysql_config,
     pmr_postgres_config,
+    pmr_redshift_config,
     Rows,
     Statements,
 )

--- a/src/pytest_mock_resources/fixture/database/relational/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/relational/__init__.py
@@ -5,8 +5,13 @@ from pytest_mock_resources.fixture.database.relational.mysql import (
     pmr_mysql_config,
 )
 from pytest_mock_resources.fixture.database.relational.postgresql import (
+    _postgres_container,
     create_postgres_fixture,
     pmr_postgres_config,
 )
-from pytest_mock_resources.fixture.database.relational.redshift import create_redshift_fixture
+from pytest_mock_resources.fixture.database.relational.redshift import (
+    _redshift_container,
+    create_redshift_fixture,
+    pmr_redshift_config,
+)
 from pytest_mock_resources.fixture.database.relational.sqlite import create_sqlite_fixture

--- a/src/pytest_mock_resources/fixture/database/relational/generic.py
+++ b/src/pytest_mock_resources/fixture/database/relational/generic.py
@@ -138,25 +138,6 @@ class EngineManager(object):
         self._create_tables(metadata)
         self._ddl_created = True
 
-    def manage(self, session=None):
-        try:
-            self._run_actions()
-
-            if session:
-                if isinstance(session, sessionmaker):
-                    session_factory = session
-                else:
-                    session_factory = sessionmaker(bind=self.engine)
-
-                Session = scoped_session(session_factory)
-                session = Session(bind=self.engine)
-                yield session
-                session.close()
-            else:
-                yield self.engine
-        finally:
-            self.engine.dispose()
-
     def manage_sync(self, session=None):
         try:
             self._run_actions()

--- a/src/pytest_mock_resources/fixture/database/relational/mysql.py
+++ b/src/pytest_mock_resources/fixture/database/relational/mysql.py
@@ -49,7 +49,7 @@ def create_mysql_fixture(*ordered_actions, scope="function", tables=None, sessio
         )
 
         engine_manager = EngineManager(engine, ordered_actions, tables=tables)
-        for engine in engine_manager.manage(session=session):
+        for engine in engine_manager.manage_sync(session=session):
             yield engine
 
     return _

--- a/src/pytest_mock_resources/fixture/database/relational/sqlite.py
+++ b/src/pytest_mock_resources/fixture/database/relational/sqlite.py
@@ -229,7 +229,7 @@ def create_sqlite_fixture(
         event.listen(raw_engine, "connect", enable_foreign_key_checks)
 
         engine_manager = EngineManager(raw_engine, ordered_actions, tables=tables)
-        for engine in engine_manager.manage(session=session):
+        for engine in engine_manager.manage_sync(session=session):
             with filter_sqlalchemy_warnings(decimal_warnings_enabled=(not decimal_warnings)):
                 assign_fixture_credentials(
                     raw_engine,


### PR DESCRIPTION
Fixes https://github.com/schireson/pytest-mock-resources/issues/80

Previously, redshift just directly used postgres' underlying
`_postgres_container` fixture. This means that you cannot simultaneously
use postgres AND redshift on different postgres database servers
(version/port would be common examples of things you might want to
customize).

Practically them being **required** to be the same container (before this PR)
makes it impossible to fully reproduce both postgres and redshift fixtures at
the same time when they operate on global resources like roles, or alter
container-wide settings like disabling foreign key checks for redshift.

Now, a separate `_redshift_container` and `RedshiftConfig` have been
added. By default they use the same values as the default postgres one;
which means that by default there will be no behavior change. A redshift
and postgres fixture, used together, will end up making use of the same
database server. However this change **enables** these configurations
to diverge for a project and use different config.

Additionally, postgres has had a lot more active development of its
fixture features. Redshift, using the postgres container, *can* make use
of all of this development, but had a completely unique implementation,
and so it did not.