### PR TITLE
fix: Use a lock when waiting for containers with --pmr-multiprocess-safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.2.1"
+version = "2.2.2"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",


### PR DESCRIPTION
I noticed that once in a while tests (with pytest-xdist) would error out because "port is already allocated", leaving behind a stopped container and a volume. Let me know if you prefer if I open an issue detailing this.
I managed to fix it on my end by putting `wait_for_container` inside a lock shared by all attempts to get a container on a certain port.
I tested it with a couple of fixtures and it seemed to work, but I was unable to run automated tests on my machine (neither using windows 11 nor wsl2 ubuntu, hopefully github actions will say everything is fine).