### PR TITLE
feat: Support non-session scoped containers.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.2.7"
+version = "2.3.0"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",
@@ -119,6 +119,7 @@ filterwarnings = [
   "ignore:urllib.parse.splitnport.*:DeprecationWarning",
   "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
   "ignore::ResourceWarning",
+  "ignore::UserWarning",
 ]
 
 [build-system]

--- a/src/pytest_mock_resources/__init__.py
+++ b/src/pytest_mock_resources/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from pytest_mock_resources.container import (
+    get_container,
     MongoConfig,
     MysqlConfig,
     PostgresConfig,
@@ -7,11 +8,6 @@ from pytest_mock_resources.container import (
     RedshiftConfig,
 )
 from pytest_mock_resources.fixture.database import (
-    _mongo_container,
-    _mysql_container,
-    _postgres_container,
-    _redis_container,
-    _redshift_container,
     create_mongo_fixture,
     create_mysql_fixture,
     create_postgres_fixture,
@@ -19,10 +15,15 @@ from pytest_mock_resources.fixture.database import (
     create_redshift_fixture,
     create_sqlite_fixture,
     pmr_mongo_config,
+    pmr_mongo_container,
     pmr_mysql_config,
+    pmr_mysql_container,
     pmr_postgres_config,
+    pmr_postgres_container,
     pmr_redis_config,
+    pmr_redis_container,
     pmr_redshift_config,
+    pmr_redshift_container,
     Rows,
     Statements,
 )

--- a/src/pytest_mock_resources/config.py
+++ b/src/pytest_mock_resources/config.py
@@ -35,9 +35,8 @@ def fallback(fn):
         if value is not None:
             return value
 
-        value = getattr(self, "_{attr}".format(attr=attr), None)
-        if value is not None:
-            return value
+        if self.has(attr):
+            return self.get(attr)
 
         try:
             return fn(self)
@@ -54,8 +53,10 @@ class DockerContainerConfig:
     _fields_defaults: Dict = {}
 
     def __init__(self, **kwargs):
-        for field in self._fields:
-            value = kwargs.get(field)
+        for field, value in kwargs.items():
+            if field not in self._fields:
+                continue
+
             attr = "_{}".format(field)
             setattr(self, attr, value)
 
@@ -67,6 +68,18 @@ class DockerContainerConfig:
                 "{}={}".format(attr, repr(getattr(self, attr))) for attr in self._fields
             ),
         )
+
+    def has(self, attr):
+        attr_name = "_{attr}".format(attr=attr)
+        return hasattr(self, attr_name)
+
+    def get(self, attr):
+        attr_name = "_{attr}".format(attr=attr)
+        return getattr(self, attr_name)
+
+    def set(self, attr, value):
+        attr_name = "_{attr}".format(attr=attr)
+        return setattr(self, attr_name, value)
 
     @fallback
     def image(self):

--- a/src/pytest_mock_resources/container/__init__.py
+++ b/src/pytest_mock_resources/container/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.mongo import MongoConfig
 from pytest_mock_resources.container.mysql import MysqlConfig
 from pytest_mock_resources.container.postgres import PostgresConfig

--- a/src/pytest_mock_resources/fixture/database/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/__init__.py
@@ -1,25 +1,25 @@
 # flake8: noqa
 from pytest_mock_resources.fixture.database.mongo import (
-    _mongo_container,
     create_mongo_fixture,
     pmr_mongo_config,
+    pmr_mongo_container,
 )
 from pytest_mock_resources.fixture.database.redis import (
-    _redis_container,
     create_redis_fixture,
     pmr_redis_config,
+    pmr_redis_container,
 )
 from pytest_mock_resources.fixture.database.relational import (
-    _mysql_container,
-    _postgres_container,
-    _redshift_container,
     create_mysql_fixture,
     create_postgres_fixture,
     create_redshift_fixture,
     create_sqlite_fixture,
     pmr_mysql_config,
+    pmr_mysql_container,
     pmr_postgres_config,
+    pmr_postgres_container,
     pmr_redshift_config,
+    pmr_redshift_container,
     Rows,
     Statements,
 )

--- a/src/pytest_mock_resources/fixture/database/mongo.py
+++ b/src/pytest_mock_resources/fixture/database/mongo.py
@@ -19,7 +19,7 @@ def pmr_mongo_config():
 
 
 @pytest.fixture(scope="session")
-def _mongo_container(pytestconfig, pmr_mongo_config):
+def pmr_mongo_container(pytestconfig, pmr_mongo_config):
     yield from get_container(pytestconfig, pmr_mongo_config)
 
 
@@ -34,7 +34,7 @@ def create_mongo_fixture(scope="function"):
     """
 
     @pytest.fixture(scope=scope)
-    def _(_mongo_container, pmr_mongo_config):
+    def _(pmr_mongo_container, pmr_mongo_config):
         return _create_clean_database(pmr_mongo_config)
 
     return _

--- a/src/pytest_mock_resources/fixture/database/redis.py
+++ b/src/pytest_mock_resources/fixture/database/redis.py
@@ -19,7 +19,7 @@ def pmr_redis_config():
 
 
 @pytest.fixture(scope="session")
-def _redis_container(pytestconfig, pmr_redis_config):
+def pmr_redis_container(pytestconfig, pmr_redis_config):
     yield from get_container(pytestconfig, pmr_redis_config)
 
 
@@ -50,7 +50,7 @@ def create_redis_fixture(scope="function"):
     """
 
     @pytest.fixture(scope=scope)
-    def _(request, _redis_container, pmr_redis_config):
+    def _(request, pmr_redis_container, pmr_redis_config):
         database_number = 0
         if hasattr(request.config, "workerinput"):
             worker_input = request.config.workerinput

--- a/src/pytest_mock_resources/fixture/database/relational/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/relational/__init__.py
@@ -1,18 +1,18 @@
 # flake8: noqa
 from pytest_mock_resources.fixture.database.relational.generic import Rows, Statements
 from pytest_mock_resources.fixture.database.relational.mysql import (
-    _mysql_container,
     create_mysql_fixture,
     pmr_mysql_config,
+    pmr_mysql_container,
 )
 from pytest_mock_resources.fixture.database.relational.postgresql import (
-    _postgres_container,
     create_postgres_fixture,
     pmr_postgres_config,
+    pmr_postgres_container,
 )
 from pytest_mock_resources.fixture.database.relational.redshift import (
-    _redshift_container,
     create_redshift_fixture,
     pmr_redshift_config,
+    pmr_redshift_container,
 )
 from pytest_mock_resources.fixture.database.relational.sqlite import create_sqlite_fixture

--- a/src/pytest_mock_resources/fixture/database/relational/mysql.py
+++ b/src/pytest_mock_resources/fixture/database/relational/mysql.py
@@ -21,7 +21,7 @@ def pmr_mysql_config():
 
 
 @pytest.fixture(scope="session")
-def _mysql_container(pytestconfig, pmr_mysql_config):
+def pmr_mysql_container(pytestconfig, pmr_mysql_config):
     yield from get_container(pytestconfig, pmr_mysql_config)
 
 
@@ -41,7 +41,7 @@ def create_mysql_fixture(*ordered_actions, scope="function", tables=None, sessio
     """
 
     @pytest.fixture(scope=scope)
-    def _(_mysql_container, pmr_mysql_config):
+    def _(pmr_mysql_container, pmr_mysql_config):
         database_name = _create_clean_database(pmr_mysql_config)
         engine = get_sqlalchemy_engine(pmr_mysql_config, database_name)
 

--- a/src/pytest_mock_resources/fixture/database/relational/postgresql.py
+++ b/src/pytest_mock_resources/fixture/database/relational/postgresql.py
@@ -21,7 +21,7 @@ def pmr_postgres_config():
 
 
 @pytest.fixture(scope="session")
-def _postgres_container(pytestconfig, pmr_postgres_config: PostgresConfig):
+def pmr_postgres_container(pytestconfig, pmr_postgres_config: PostgresConfig):
     yield from get_container(pytestconfig, pmr_postgres_config)
 
 
@@ -59,12 +59,12 @@ def create_postgres_fixture(
     )
 
     @pytest.fixture(scope=scope)
-    def _sync(_postgres_container, pmr_postgres_config):
+    def _sync(pmr_postgres_container, pmr_postgres_config):
         engine_manager = create_engine_manager(pmr_postgres_config, **engine_manager_kwargs)
         yield from engine_manager.manage_sync(session=session)
 
     @pytest.fixture(scope=scope)
-    async def _async(_postgres_container, pmr_postgres_config):
+    async def _async(pmr_postgres_container, pmr_postgres_config):
         engine_manager = create_engine_manager(pmr_postgres_config, **engine_manager_kwargs)
         async for engine in engine_manager.manage_async(session=session):
             yield engine

--- a/src/pytest_mock_resources/fixture/database/relational/redshift/__init__.py
+++ b/src/pytest_mock_resources/fixture/database/relational/redshift/__init__.py
@@ -21,7 +21,7 @@ def pmr_redshift_config():
 
 
 @pytest.fixture(scope="session")
-def _redshift_container(pytestconfig, pmr_redshift_config):
+def pmr_redshift_container(pytestconfig, pmr_redshift_config):
     yield from get_container(pytestconfig, pmr_redshift_config)
 
 
@@ -68,7 +68,7 @@ def create_redshift_fixture(
     )
 
     @pytest.fixture(scope=scope)
-    def _sync(_redshift_container, pmr_redshift_config):
+    def _sync(pmr_redshift_container, pmr_redshift_config):
         engine_manager = create_engine_manager(pmr_redshift_config, **engine_manager_kwargs)
         database_name = engine_manager.engine.url.database
 
@@ -78,7 +78,7 @@ def create_redshift_fixture(
                 yield engine
 
     @pytest.fixture(scope=scope)
-    async def _async(_redshift_container, pmr_redshift_config):
+    async def _async(pmr_redshift_container, pmr_redshift_config):
         engine_manager = create_engine_manager(pmr_redshift_config, **engine_manager_kwargs)
         database_name = engine_manager.engine.url.database
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from pytest_mock_resources.compat import sqlalchemy
@@ -5,4 +7,9 @@ from pytest_mock_resources.compat import sqlalchemy
 skip_if_sqlalchemy2 = pytest.mark.skipif(
     sqlalchemy.version.startswith("1.4") or sqlalchemy.version.startswith("2."),
     reason="Incompatible with sqlalchemy 2 behavior",
+)
+
+skip_if_ci = pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Incompatible with CI behavior",
 )

--- a/tests/fixture/non_session_container/test_dynamic_port.py
+++ b/tests/fixture/non_session_container/test_dynamic_port.py
@@ -1,0 +1,41 @@
+"""Test the ability for non-session container fixtures to dynamically
+
+While these tests can execute in CI, as-is, they wont test fixture
+teardown of containers in CI (where the container is pre-allocated by
+CI). Perhaps something can be worked out using a dind kind of setup.
+"""
+import pytest
+from sqlalchemy import text
+
+from pytest_mock_resources import create_postgres_fixture, get_container, PostgresConfig
+from tests import skip_if_ci
+
+
+@pytest.fixture(scope="session")
+def pmr_postgres_config():
+    return PostgresConfig(port=None)
+
+
+@pytest.fixture
+def pmr_postgres_container(pytestconfig, pmr_postgres_config: PostgresConfig):
+    yield from get_container(pytestconfig, pmr_postgres_config)
+
+
+pg = create_postgres_fixture(session=True)
+
+
+@skip_if_ci
+class Test_postgres_fixture:
+    """Test the postgres fixture.
+
+    We need at least 2 (or more) tests to verify that the fixtures are not
+    clobbering one another.
+    """
+    def test_one(self, pg):
+        pg.execute(text("select 1"))
+
+    def test_two(self, pg):
+        pg.execute(text("select 1"))
+
+    def test_three(self, pg):
+        pg.execute(text("select 1"))

--- a/tests/fixture/non_session_container/test_static_port.py
+++ b/tests/fixture/non_session_container/test_static_port.py
@@ -1,0 +1,34 @@
+"""Test the ability for non-session container fixtures to be overridden.
+
+While these tests can execute in CI, as-is, they wont test fixture
+teardown of containers in CI (where the container is pre-allocated by
+CI). Perhaps something can be worked out using a dind kind of setup.
+"""
+import pytest
+from sqlalchemy import text
+
+from pytest_mock_resources import create_postgres_fixture, get_container, PostgresConfig
+
+
+@pytest.fixture
+def pmr_postgres_container(pytestconfig, pmr_postgres_config: PostgresConfig):
+    yield from get_container(pytestconfig, pmr_postgres_config)
+
+
+pg = create_postgres_fixture(session=True)
+
+
+class Test_postgres_fixture:
+    """Test the postgres fixture.
+
+    We need at least 2 (or more) tests to verify that the fixtures are not
+    clobbering one another.
+    """
+    def test_one(self, pg):
+        pg.execute(text("select 1"))
+
+    def test_two(self, pg):
+        pg.execute(text("select 1"))
+
+    def test_three(self, pg):
+        pg.execute(text("select 1"))

--- a/tests/test_non_session_container.py
+++ b/tests/test_non_session_container.py
@@ -1,0 +1,9 @@
+import pytest
+
+from pytest_mock_resources.container.postgres import PostgresConfig
+
+
+@pytest.fixture(scope="session")
+def pmr_postgres_config():
+    print('asdfasdfasdf')
+    return PostgresConfig(port=None)


### PR DESCRIPTION
In an effort to enable tests which operate at the whole-database level (interacting with roles/permissions/multiple databases/etc), non-session scoped container fixtures will enable per-test containers.

Additionally, opting **out** of a specific port enables dynamic port selection which enables this feature to still work correctly in multiprocess tests.

Currently this feature is experimental, and thus undocumented.