### PR TITLE
Prefer PYTEST_MOCK_RESOURCES_HOST environment variable if it is set when determining host

### DIFF
--- a/src/pytest_mock_resources/config.py
+++ b/src/pytest_mock_resources/config.py
@@ -91,10 +91,13 @@ class DockerContainerConfig:
 
     @fallback
     def host(self):
+        if os.environ.get("PYTEST_MOCK_RESOURCES_HOST") is not None:
+            return os.environ.get("PYTEST_MOCK_RESOURCES_HOST")
+
         if is_docker_host():
             return _DOCKER_HOST
 
-        return os.environ.get("PYTEST_MOCK_RESOURCES_HOST", "localhost")
+        return "localhost"
 
     @fallback
     def port(self):


### PR DESCRIPTION
Addresses #160 