### PR TITLE
fix: Docs build.

### DIFF
--- a/docs/source/fixtures.rst
+++ b/docs/source/fixtures.rst
@@ -11,6 +11,16 @@ A new resource (database or otherwise) is created on a per test database, which 
 fixture to be used in multiple tests without risking data leakage or side-effects from one
 test to another.
 
+.. note::
+
+   By default the underlying containers are reused across tests to amortize the container startup
+   cost. Tests then create new "resources" (e.g. databases) within that container to avoid
+   inter-test pollution.
+
+   This **can** cause inter-test dependencies if your tests are altering container-global resources
+   like database users. In the event this is a problem, resources can be configured to **not**
+   be session fixtures, although this will likely be drastically slower overall.
+
 See :ref:`Config` for information on customizing the configuration for docker-based fixtures.
 
 .. toctree::

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,9 @@
 build:
-    image: latest
+  image: latest
 
 python:
-    version: 3.6
-    pip_install: true
+  version: 3.7
+  pip_install: true
 
 requirements: docs/requirements.txt
 sphinx:


### PR DESCRIPTION
Fixes https://github.com/schireson/pytest-mock-resources/issues/96 and fixes the failing docs build.