### PR TITLE
fix: Move port selection into the filelock.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,17 @@ jobs:
       python-versions: '["3.7", "3.8", "3.9", "3.10"]'
       lint: false
 
+  test:
+    uses: ./.github/workflows/lint_and_test.yml
+    with:
+      install: make install
+      lint: false
+      sqlalchemy-versions: '["1.4.39"]'
+      python-versions: '["3.10"]'
+
   test-and-lint:
     uses: ./.github/workflows/lint_and_test.yml
     with:
       install: make install
       sqlalchemy-versions: '["1.4.39"]'
-      python-versions: '["3.7", "3.8", "3.9", "3.10"]'
+      python-versions: '["3.7", "3.8", "3.9"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.6.3"
+version = "2.6.4"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",
@@ -119,6 +119,7 @@ markers = [
 ]
 filterwarnings = [
   "error",
+  "ignore:There is no current event loop:DeprecationWarning",
 ]
 
 [build-system]


### PR DESCRIPTION
This is primarily useful when `port` is set to `None`, leading to random port selction for the scope of fixture being used.

The expectation is that for tests not using this feature, the port selection is a simple lookup and therefore the lock contention will only apply 1 or (-n N) N times, such that the differnce to everyone else is negligible.