### PR TITLE
feat: Ensure all fixture types are automatically included in the CLI.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.6.11"
+version = "2.6.12"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/__init__.py
+++ b/src/pytest_mock_resources/__init__.py
@@ -1,6 +1,7 @@
 from pytest_mock_resources.container import (
     get_container,
     MongoConfig,
+    MotoConfig,
     MysqlConfig,
     PostgresConfig,
     RedisConfig,
@@ -40,6 +41,7 @@ from pytest_mock_resources.sqlalchemy import Rows, Statements, StaticStatements
 __all__ = [
     "Credentials",
     "MongoConfig",
+    "MotoConfig",
     "MysqlConfig",
     "PostgresConfig",
     "RedisConfig",

--- a/src/pytest_mock_resources/config.py
+++ b/src/pytest_mock_resources/config.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import functools
 import os
 import socket
-from typing import Dict, Iterable
+from typing import ClassVar, Dict, Iterable, Type
 
 _DOCKER_HOST = "host.docker.internal"
 
@@ -49,8 +51,16 @@ def fallback(fn):
 
 
 class DockerContainerConfig:
+    name: ClassVar[str]
+
     _fields: Iterable = {"image", "host", "port", "ci_port", "container_args"}
     _fields_defaults: Dict = {}
+
+    subclasses: Dict[str, Type[DockerContainerConfig]] = {}
+
+    @classmethod
+    def __init_subclass__(cls):
+        DockerContainerConfig.subclasses[cls.name] = cls
 
     def __init__(self, **kwargs):
         for field, value in kwargs.items():

--- a/src/pytest_mock_resources/container/__init__.py
+++ b/src/pytest_mock_resources/container/__init__.py
@@ -1,7 +1,18 @@
-# flake8: noqa
 from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.mongo import MongoConfig
+from pytest_mock_resources.container.moto import MotoConfig
 from pytest_mock_resources.container.mysql import MysqlConfig
 from pytest_mock_resources.container.postgres import PostgresConfig
 from pytest_mock_resources.container.redis import RedisConfig
 from pytest_mock_resources.container.redshift import RedshiftConfig
+
+__all__ = [
+    "get_container",
+    "MongoConfig",
+    "MysqlConfig",
+    "PostgresConfig",
+    "PostgresConfig",
+    "RedisConfig",
+    "RedshiftConfig",
+    "MotoConfig",
+]

--- a/src/pytest_mock_resources/container/moto.py
+++ b/src/pytest_mock_resources/container/moto.py
@@ -16,7 +16,8 @@ class MotoConfig(DockerContainerConfig):
             Defaults to :code:`5432`.
     """
 
-    name = "postgres"
+    name = "moto"
+
     _fields = {"image", "host", "port"}
     _fields_defaults = {
         "image": "motoserver/moto:4.0.6",


### PR DESCRIPTION
I noticed moto was missing when trying to manually start it. This new strategy should ensure that new options are always included, so long as they subclass the base docker config object.