### PR TITLE
fix: Increase time to wait for mysql to spin up.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.6.12"
+version = "2.6.13"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/fixture/mysql.py
+++ b/src/pytest_mock_resources/fixture/mysql.py
@@ -21,7 +21,7 @@ def pmr_mysql_config():
 
 @pytest.fixture(scope="session")
 def pmr_mysql_container(pytestconfig, pmr_mysql_config):
-    yield from get_container(pytestconfig, pmr_mysql_config)
+    yield from get_container(pytestconfig, pmr_mysql_config, interval=1, retries=60)
 
 
 def create_mysql_fixture(


### PR DESCRIPTION
Noticed in sqlalchemy-declarative-extensions tests, which necessarily spin up/down a lot of mysql instances, versus just sharing a single one.

The default of 0.5 semiregularly leads to test failures (primarily in CI) that go away if you increase either the retry number of the interval. Given that mysql's startup is noticeably longer than something like postgres/redis, the higher interval seemed more appropriate.