### PR TITLE
docs: Fix typos

### DIFF
--- a/docs/source/mongo.rst
+++ b/docs/source/mongo.rst
@@ -1,7 +1,7 @@
 Mongo
 =====
 
-Users can test MongoDB dependant code using the `create_mongo_fixture`.
+Users can test MongoDB dependent code using the `create_mongo_fixture`.
 
 Consider the following example:
 

--- a/docs/source/relational/ordered-actions.rst
+++ b/docs/source/relational/ordered-actions.rst
@@ -6,7 +6,7 @@ is often not useful by itself. You'll need to populate that database with
 some minimal amount of schemata and/or data in order to be useful.
 
 To address this, the :code:`create_*_fixture` functions take in an optional number
-of "Ordered Actions" whcih can be used to *setup* the fixture prior to you using it.
+of "Ordered Actions" which can be used to *setup* the fixture prior to you using it.
 As the name might imply, the "actions" are executed, in order, before the test
 body is entered.
 

--- a/docs/source/relational/template-database.rst
+++ b/docs/source/relational/template-database.rst
@@ -49,7 +49,7 @@ Static Actions
 --------------
 Static actions are actions which are safe to be executed exactly once, because they
 have predictable semantics which both safely be executed once per test session,
-as well as happen in a completely separate transactiona and database, from the
+as well as happen in a completely separate transactions and database, from the
 one handed to the test.
 
 Static actions include:
@@ -86,7 +86,7 @@ Dynamic actions include:
    actions will be executed as though they were dynamic (i.e. per-test-database).
 
    You should therefore prefer to group all static actions before dynamic ones
-   whereever possible to ensure you get the most optimal amortization of actions.
+   wherever possible to ensure you get the most optimal amortization of actions.
 
    For example:
 

--- a/docs/source/sqlite.rst
+++ b/docs/source/sqlite.rst
@@ -36,7 +36,7 @@ SQLite generally would produce an error upon use of that table, but will now wor
 behave similarly to postgres.
 
 A caveat to this is that SQLite has no notion of a "search path" like in postgres. Therefore,
-programatic use altering the search path from the default "public" (in postgres), or referencing
+programmatic use altering the search path from the default "public" (in postgres), or referencing
 a "public" table as "public.tablename" would not be supported.
 
 

--- a/src/pytest_mock_resources/cli.py
+++ b/src/pytest_mock_resources/cli.py
@@ -40,7 +40,7 @@ def main():
 
 def create_parser():
     parser = argparse.ArgumentParser(
-        description="Premptively run docker containers to speed up initial startup of PMR Fixtures."
+        description="Preemptively run docker containers to speed up initial startup of PMR Fixtures."
     )
     parser.add_argument(
         "fixtures",

--- a/src/pytest_mock_resources/fixture/base.py
+++ b/src/pytest_mock_resources/fixture/base.py
@@ -12,7 +12,7 @@ def generate_fixture_id(enabled: bool = True, name=""):
 
 def asyncio_fixture(async_fixture, scope="function"):
     # pytest-asyncio in versions >=0.17 force you to use a `pytest_asyncio.fixture`
-    # call instead of `pytest.fixture`. Given that this would introduce an unncessary
+    # call instead of `pytest.fixture`. Given that this would introduce an unnecessary
     # dependency on pytest-asyncio (when there are other alternatives) seems less than
     # ideal, so instead we can just set the flag that they set, as the indicator.
     async_fixture._force_asyncio_fixture = True

--- a/src/pytest_mock_resources/fixture/postgresql.py
+++ b/src/pytest_mock_resources/fixture/postgresql.py
@@ -18,7 +18,7 @@ class DatabaseExistsError(RuntimeError):
     """Raise when the database being created already exists.
 
     This exception commonly occurs during multiprocess test execution, as a
-    sentinel for gracefully continueing among test workers which attempt to create
+    sentinel for gracefully continuing among test workers which attempt to create
     the same database.
     """
 

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -32,7 +32,7 @@ def create_redis_fixture(scope="function"):
     .. note::
 
        If running tests in parallel, the implementation fans out to different redis "database"s,
-       up to a 16 (which is the default container fixed limite). This means you can only run
+       up to a 16 (which is the default container fixed limit). This means you can only run
        up to 16 simultaneous tests.
 
        Additionally, any calls to `flushall` or any other cross-database calls **will** still

--- a/src/pytest_mock_resources/fixture/redshift/__init__.py
+++ b/src/pytest_mock_resources/fixture/redshift/__init__.py
@@ -43,7 +43,7 @@ def create_redshift_fixture(
     database server.
 
     Note that, by default, redshift uses a postgres container as the database server
-    and attempts to reintroduce appoximations of Redshift features, such as
+    and attempts to reintroduce approximations of Redshift features, such as
     S3 COPY/UNLOAD, redshift-specific functions, and other specific behaviors.
 
     Arguments:

--- a/src/pytest_mock_resources/fixture/sqlite.py
+++ b/src/pytest_mock_resources/fixture/sqlite.py
@@ -1,6 +1,6 @@
 """Adapt SQLite to act more in line with typical postgresql usage.
 
-SQLite is a desireable test database target because it introduces much less latency across
+SQLite is a desirable test database target because it introduces much less latency across
 tests, is parallelizable, and has a lower minimum fixed test-startup cost.
 
 Unfortunately, SQLite and postgresql do not behave identically in all cases. However, in
@@ -115,7 +115,7 @@ def make_postgres_like_sqlite_dialect():
             return "BLOB"
 
     class PostgresLikeDialect(SQLiteDialect_pysqlite):
-        """Define the dialect that collects all postgres-like adapations."""
+        """Define the dialect that collects all postgres-like adaptations."""
 
         name = "pmrsqlite"
 

--- a/src/pytest_mock_resources/patch/redshift/mock_s3_copy.py
+++ b/src/pytest_mock_resources/patch/redshift/mock_s3_copy.py
@@ -61,7 +61,7 @@ def _parse_s3_command(statement):
             (
                 "Possibly malformed S3 URI Format. "
                 "Statement = {statement}"
-                "Redshift fixture only supports S3 Copy statments with the following syntax: "
+                "Redshift fixture only supports S3 Copy statements with the following syntax: "
                 "COPY <table_name> FROM [(column 1, [column2, [..]])] '<file path on S3 bucket>' "
                 "credentials 'aws_access_key_id=<aws_access_key_id>;"
                 "aws_secret_access_key=<aws_secret_access_key>'"
@@ -95,7 +95,7 @@ def _parse_s3_command(statement):
                         (
                             "Possibly malformed AWS Credentials Format. "
                             "Statement = {statement}"
-                            "Redshift fixture only supports S3 Copy statments with the following "
+                            "Redshift fixture only supports S3 Copy statements with the following "
                             "syntax: COPY <table_name> FROM [(column 1, [column2, [..]])] '"
                             "<file path on S3 bucket>' "
                             "credentials 'aws_access_key_id=<aws_access_key_id>;"

--- a/src/pytest_mock_resources/patch/redshift/mock_s3_unload.py
+++ b/src/pytest_mock_resources/patch/redshift/mock_s3_unload.py
@@ -42,7 +42,7 @@ def _parse_s3_command(statement):
             (
                 "Possibly malformed SELECT Statement. "
                 "Statement = {statement}"
-                "Redshift fixture only supports S3 Unload statments with the following syntax: "
+                "Redshift fixture only supports S3 Unload statements with the following syntax: "
                 "UNLOAD ('select-statement') TO 's3://object-path/name-prefix'"
                 "authorization 'aws_access_key_id=<aws_access_key_id>;"
                 "aws_secret_access_key=<aws_secret_access_key>'"
@@ -56,7 +56,7 @@ def _parse_s3_command(statement):
             (
                 "Possibly malformed S3 URI Format. "
                 "Statement = {statement}"
-                "Redshift fixture only supports S3 Unload statments with the following syntax: "
+                "Redshift fixture only supports S3 Unload statements with the following syntax: "
                 "UNLOAD ('select-statement') TO 's3://object-path/name-prefix'"
                 "authorization 'aws_access_key_id=<aws_access_key_id>;"
                 "aws_secret_access_key=<aws_secret_access_key>'"
@@ -90,7 +90,7 @@ def _parse_s3_command(statement):
                         (
                             "Possibly malformed AWS Credentials Format. "
                             "Statement = {statement}"
-                            "Redshift fixture only supports S3 Copy statments with the following "
+                            "Redshift fixture only supports S3 Copy statements with the following "
                             "syntax: COPY <table_name> FROM [(column 1, [column2, [..]])] '"
                             "<file path on S3 bucket>' "
                             "credentials 'aws_access_key_id=<aws_access_key_id>;"
@@ -120,7 +120,7 @@ def _parse_s3_command(statement):
                     (
                         "Possibly malformed Delimiter Format. "
                         "Statement = {statement}"
-                        "Redshift fixture only supports S3 Unload statments with the following"
+                        "Redshift fixture only supports S3 Unload statements with the following"
                         "syntax: UNLOAD ('select-statement') TO 's3://object-path/name-prefix'"
                         "authorization 'aws_access_key_id=<aws_access_key_id>;"
                         "aws_secret_access_key=<aws_secret_access_key>'"

--- a/src/pytest_mock_resources/sqlalchemy.py
+++ b/src/pytest_mock_resources/sqlalchemy.py
@@ -323,5 +323,5 @@ def commit(conn):
 
         return conn.execute(text("COMMIT"))
     except sqlalchemy.exc.InvalidRequestError:
-        # In autocommit mode, we wont be able to commit.
+        # In autocommit mode, we won't be able to commit.
         pass

--- a/tests/examples/test_multiprocess_container_cleanup_race_condition/test_split.py
+++ b/tests/examples/test_multiprocess_container_cleanup_race_condition/test_split.py
@@ -12,7 +12,7 @@ will have a local reference to the created `container` object.
 So when it goes to try to clean up its container, any remaining tests in other
 workers may still be attempting to use the container and will fail.
 
-Often this **doesnt** happen because cleanup of session fixtures is the last
+Often this **doesn't** happen because cleanup of session fixtures is the last
 thing to happen. Perhaps the first worker which produces the container is also
 the one which is most likely to complete last. Notably, due to the way (at least
 **our**) CircleCI docker config works, this test will strictly **always** pass

--- a/tests/fixture/non_session_container/test_dynamic_port.py
+++ b/tests/fixture/non_session_container/test_dynamic_port.py
@@ -1,6 +1,6 @@
 """Test the ability for non-session container fixtures to dynamically
 
-While these tests can execute in CI, as-is, they wont test fixture
+While these tests can execute in CI, as-is, they won't test fixture
 teardown of containers in CI (where the container is pre-allocated by
 CI). Perhaps something can be worked out using a dind kind of setup.
 """

--- a/tests/fixture/non_session_container/test_static_port.py
+++ b/tests/fixture/non_session_container/test_static_port.py
@@ -1,6 +1,6 @@
 """Test the ability for non-session container fixtures to be overridden.
 
-While these tests can execute in CI, as-is, they wont test fixture
+While these tests can execute in CI, as-is, they won't test fixture
 teardown of containers in CI (where the container is pre-allocated by
 CI). Perhaps something can be worked out using a dind kind of setup.
 """


### PR DESCRIPTION
Found via `codespell -L smove`