### PR TITLE
fix: Set the region when creating the client to assume roles.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.9.0"
+version = "2.9.1"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/fixture/moto/base.py
+++ b/src/pytest_mock_resources/fixture/moto/base.py
@@ -103,6 +103,7 @@ class Credentials:
             endpoint_url=url,
             aws_access_key_id="test",
             aws_secret_access_key="test",
+            region_name=region_name,
         )
         response = sts.assume_role(
             RoleArn=f"arn:aws:iam::{account_id}:role/my-role",


### PR DESCRIPTION
Fixes an issue where certain uses' lack of aws env vars being set lead to a missing region error. I had thought this was fixed in the prior PR, not sure how this got passed it before, because it should be being hit in every invocation.