### PR TITLE
feat: Implement support for "client_call" in python on whales, with a…

### DIFF
--- a/src/pytest_mock_resources/cli.py
+++ b/src/pytest_mock_resources/cli.py
@@ -65,7 +65,9 @@ def execute(fixture: str, pytestconfig: StubPytestConfig, start=True, stop=False
             pass
 
     if stop:
-        from python_on_whales import docker
+        from .whales import get_docker_client
+
+        docker = get_docker_client()
 
         assert config.port
         name = container_name(fixture, int(config.port))

--- a/src/pytest_mock_resources/container/base.py
+++ b/src/pytest_mock_resources/container/base.py
@@ -122,7 +122,9 @@ def wait_for_container(config, *, retries=DEFAULT_RETRIES, interval=DEFAULT_INTE
     The caller must provide a `check_fn` which should `raise ContainerCheckFailed` if
     it finds that the container is not yet up.
     """
-    from python_on_whales import docker
+    from ..whales import get_docker_client
+
+    docker = get_docker_client()
 
     if config.port is None:
         config.set("port", unused_tcp_port())

--- a/src/pytest_mock_resources/hooks.py
+++ b/src/pytest_mock_resources/hooks.py
@@ -84,7 +84,9 @@ def pytest_sessionfinish(session, exitstatus):
 
     # docker-based fixtures should be optional based on the selected extras.
     try:
-        from python_on_whales import docker
+        from .whales import get_docker_client
+
+        docker = get_docker_client()
     except ImportError:
         return
 

--- a/src/pytest_mock_resources/whales.py
+++ b/src/pytest_mock_resources/whales.py
@@ -1,0 +1,14 @@
+from shutil import which
+
+from python_on_whales import DockerClient
+
+
+def get_docker_client():
+    clients = ["docker", "podman", "nerdctl"]
+
+    for client in clients:
+        which_result = which(client)
+
+        if which_result is not None:
+            return DockerClient(client_call=[client])
+    return DockerClient(client_call=[clients[0]])


### PR DESCRIPTION
…uto-detection of podman/nerdctl


On systems that have podman/nerdctl available, this PR adds support for detecting the appropriate runtime, and use it via `client_call` feature provided by python on whales.

If no runtime is detected, it falls back to `docker` as is the default