### PR TITLE
fix: also allow psycopg2-binary as a valid driver

### DIFF
--- a/src/pytest_mock_resources/container/postgres.py
+++ b/src/pytest_mock_resources/container/postgres.py
@@ -135,7 +135,7 @@ def detect_driver(drivername: Optional[str] = None, async_: bool = False) -> str
         if any(Distribution.discover(name="asyncpg")):
             return "postgresql+asyncpg"
     else:
-        if any(Distribution.discover(name="psycopg2")):
+        if any(Distribution.discover(name="psycopg2")) or any(Distribution.discover(name="psycopg2-binary")):
             return "postgresql+psycopg2"
 
     raise ValueError(  # pragma: no cover


### PR DESCRIPTION
v2.10.2 introduced a change that broke our CI since we use `psycopg2-binary` instead of `psycopg2`.

This change allows either as a valid driver.