### PR TITLE
RFC: Allow Redis fixture to use `decode_responses` parameter

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -18,7 +17,7 @@ version = "1.2.2"
 extensions = [
     "m2r2",
     "sphinx.ext.autodoc",
-    'sphinx_autodoc_typehints',
+    "sphinx_autodoc_typehints",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
@@ -26,7 +25,7 @@ extensions = [
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-source_suffix = ['.rst', '.md']
+source_suffix = [".rst", ".md"]
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]

--- a/src/pytest_mock_resources/container/postgres.py
+++ b/src/pytest_mock_resources/container/postgres.py
@@ -135,7 +135,9 @@ def detect_driver(drivername: Optional[str] = None, async_: bool = False) -> str
         if any(Distribution.discover(name="asyncpg")):
             return "postgresql+asyncpg"
     else:
-        if any(Distribution.discover(name="psycopg2")) or any(Distribution.discover(name="psycopg2-binary")):
+        if any(Distribution.discover(name="psycopg2")) or any(
+            Distribution.discover(name="psycopg2-binary")
+        ):
             return "postgresql+psycopg2"
 
     raise ValueError(  # pragma: no cover

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -26,11 +26,13 @@ class RedisConfig(DockerContainerConfig):
         "host",
         "port",
         "ci_port",
+        "decode_responses",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "redis:5.0.7",
         "port": 6380,
         "ci_port": 6379,
+        "decode_responses": False,
     }
 
     def ports(self):

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -17,6 +17,8 @@ class RedisConfig(DockerContainerConfig):
             Defaults to :code:`6380`.
         ci_port (int): The port to bind the container to when a CI environment is detected.
             Defaults to :code:`6379`.
+        decode_responses (bool): Whether to decode responses from the server on the client.
+            Defaults to :code:`False`.
     """
 
     name = "redis"

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -21,11 +21,18 @@ class RedisConfig(DockerContainerConfig):
 
     name = "redis"
 
-    _fields: ClassVar[Iterable] = {"image", "host", "port", "ci_port"}
+    _fields: ClassVar[Iterable] = {
+        "image",
+        "host",
+        "port",
+        "ci_port",
+        "decode_responses",
+    }
     _fields_defaults: ClassVar[dict] = {
         "image": "redis:5.0.7",
         "port": 6380,
         "ci_port": 6379,
+        "decode_responses": False,
     }
 
     def ports(self):

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -1,7 +1,7 @@
 from typing import ClassVar, Iterable
 
 from pytest_mock_resources.compat import redis
-from pytest_mock_resources.config import DockerContainerConfig
+from pytest_mock_resources.config import DockerContainerConfig, fallback
 from pytest_mock_resources.container.base import ContainerCheckFailed
 
 
@@ -36,6 +36,10 @@ class RedisConfig(DockerContainerConfig):
         "ci_port": 6379,
         "decode_responses": False,
     }
+
+    @fallback
+    def decode_responses(self):
+        raise NotImplementedError()
 
     def ports(self):
         return {6379: self.port}

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -26,13 +26,11 @@ class RedisConfig(DockerContainerConfig):
         "host",
         "port",
         "ci_port",
-        "decode_responses",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "redis:5.0.7",
         "port": 6380,
         "ci_port": 6379,
-        "decode_responses": False,
     }
 
     def ports(self):

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_mock_resources.compat import redis
 from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.redis import RedisConfig

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -23,7 +23,7 @@ def pmr_redis_container(pytestconfig, pmr_redis_config):
     yield from get_container(pytestconfig, pmr_redis_config)
 
 
-def create_redis_fixture(scope="function"):
+def create_redis_fixture(scope="function", decode_responses: bool = False):
     """Produce a Redis fixture.
 
     Any number of fixture functions can be created. Under the hood they will all share the same
@@ -44,6 +44,7 @@ def create_redis_fixture(scope="function"):
 
     Args:
         scope (str): The scope of the fixture can be specified by the user, defaults to "function".
+        decode_responses (bool): Whether to decode the responses from redis.
 
     Raises:
         KeyError: If any additional arguments are provided to the function than what is necessary.
@@ -66,7 +67,7 @@ def create_redis_fixture(scope="function"):
             host=pmr_redis_config.host,
             port=pmr_redis_config.port,
             db=database_number,
-            decode_responses=pmr_redis_config.decode_responses,
+            decode_responses=decode_responses,
         )
         db.flushdb()
 

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pytest_mock_resources.compat import redis
 from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.redis import RedisConfig
@@ -62,7 +61,12 @@ def create_redis_fixture(scope="function"):
                 "The redis fixture currently only supports up to 16 parallel executions"
             )
 
-        db = redis.Redis(host=pmr_redis_config.host, port=pmr_redis_config.port, db=database_number)
+        db = redis.Redis(
+            host=pmr_redis_config.host,
+            port=pmr_redis_config.port,
+            db=database_number,
+            decode_responses=pmr_redis_config.decode_responses,
+        )
         db.flushdb()
 
         Credentials.assign_from_credentials(

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pytest_mock_resources.compat import redis
 from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.redis import RedisConfig
@@ -67,7 +66,7 @@ def create_redis_fixture(scope="function", decode_responses: bool = False):
             host=pmr_redis_config.host,
             port=pmr_redis_config.port,
             db=database_number,
-            decode_responses=decode_responses,
+            decode_responses=decode_responses or pmr_redis_config.decode_responses,
         )
         db.flushdb()
 

--- a/tests/fixture/test_redis.py
+++ b/tests/fixture/test_redis.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_mock_resources import create_redis_fixture
 from pytest_mock_resources.compat import redis
 
@@ -255,9 +256,7 @@ class TestLists:
         _list_setup(redis_client)
         assert redis_client.llen("dbs") == 5
         assert redis_client.lindex("dbs", 1) == ("mysql" if is_decoded else b"mysql")
-        assert redis_client.lpop("dbs") == (
-            "mysql_lite" if is_decoded else b"mysql_lite"
-        )
+        assert redis_client.lpop("dbs") == ("mysql_lite" if is_decoded else b"mysql_lite")
 
         redis_client.rpush("dbs", "RabbitMQ")
         assert redis_client.rpop("dbs") == ("RabbitMQ" if is_decoded else b"RabbitMQ")
@@ -265,7 +264,5 @@ class TestLists:
         redis_client.ltrim("dbs", 1, -1)
         rest = redis_client.lrange("dbs", 0, -1)
         assert rest == (
-            ["postgres", "redis", "mongo"]
-            if is_decoded
-            else [b"postgres", b"redis", b"mongo"]
+            ["postgres", "redis", "mongo"] if is_decoded else [b"postgres", b"redis", b"mongo"]
         )

--- a/tests/fixture/test_redis.py
+++ b/tests/fixture/test_redis.py
@@ -1,7 +1,11 @@
+import pytest
 from pytest_mock_resources import create_redis_fixture
 from pytest_mock_resources.compat import redis
 
 redis_client = create_redis_fixture()
+redis_client_decode = create_redis_fixture(decode_responses=True)
+
+client_parameters = [("redis_client", False), ("redis_client_decode", True)]
 
 
 def _sets_setup(redis_client):
@@ -42,83 +46,151 @@ class TestGeneric:
         assert value == "bar"
 
 
+@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestStrings:
-    def test_set(self, redis_client):
+    def test_set(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         redis_client.set("foo", "bar")
-        value = redis_client.get("foo").decode("utf-8")
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
         assert value == "bar"
 
-    def test_append(self, redis_client):
+    def test_append(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         redis_client.set("foo", "bar")
         redis_client.append("foo", "baz")
-        value = redis_client.get("foo").decode("utf-8")
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
         assert value == "barbaz"
 
-    def test_int_operations(self, redis_client):
+    def test_int_operations(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         redis_client.set("foo", 1)
         redis_client.incr("foo")
-        value = int(redis_client.get("foo").decode("utf-8"))
-        assert value == 2
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert int(value) == 2
 
         redis_client.decr("foo")
-        value = int(redis_client.get("foo").decode("utf-8"))
-        assert value == 1
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert int(value) == 1
 
         redis_client.incrby("foo", 4)
-        value = int(redis_client.get("foo").decode("utf-8"))
-        assert value == 5
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert int(value) == 5
 
         redis_client.decrby("foo", 3)
-        value = int(redis_client.get("foo").decode("utf-8"))
-        assert value == 2
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
 
-    def test_float_operations(self, redis_client):
+        assert int(value) == 2
+
+    def test_float_operations(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         redis_client.set("foo", 1.2)
-        value = float(redis_client.get("foo").decode("utf-8"))
-        assert value == 1.2
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert float(value) == 1.2
 
         redis_client.incrbyfloat("foo", 4.1)
-        value = float(redis_client.get("foo").decode("utf-8"))
-        assert value == 5.3
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert float(value) == 5.3
 
         redis_client.incrbyfloat("foo", -3.1)
-        value = float(redis_client.get("foo").decode("utf-8"))
-        assert value == 2.2
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert float(value) == 2.2
 
-    def test_multiple_keys(self, redis_client):
+    def test_multiple_keys(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         test_mapping = {"foo": "bar", "baz": 1, "flo": 1.2}
         redis_client.mset(test_mapping)
-        assert redis_client.get("foo").decode("utf-8") == "bar"
-        assert int(redis_client.get("baz").decode("utf-8")) == 1
-        assert float(redis_client.get("flo").decode("utf-8")) == 1.2
 
-    def test_querries(self, redis_client):
+        value = redis_client.get("foo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert value == "bar"
+
+        value = redis_client.get("baz")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert int(value) == 1
+
+        value = redis_client.get("flo")
+        if not is_decoded:
+            value = value.decode("utf-8")
+        assert float(value) == 1.2
+
+    def test_querries(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         test_mapping = {"foo1": "bar1", "foo2": "bar2", "flo": "flo"}
         redis_client.mset(test_mapping)
         foo_keys = redis_client.keys("foo*")
-        assert b"foo1" in foo_keys
-        assert b"foo2" in foo_keys
-        assert b"flo" not in foo_keys
+        if is_decoded:
+            assert "foo1" in foo_keys
+            assert "foo2" in foo_keys
+            assert "flo" not in foo_keys
+        else:
+            assert b"foo1" in foo_keys
+            assert b"foo2" in foo_keys
+            assert b"flo" not in foo_keys
 
 
+@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestSets:
-    def test_sadd(self, redis_client):
+    def test_sadd(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _sets_setup(redis_client)
         friends_leto = redis_client.smembers("friends:leto")
         friends_paul = redis_client.smembers("friends:paul")
-        assert friends_leto == {b"duncan", b"ghanima"}
-        assert friends_paul == {b"gurney", b"duncan"}
 
-    def test_set_operations(self, redis_client):
+        if is_decoded:
+            assert friends_leto == {"duncan", "ghanima"}
+            assert friends_paul == {"gurney", "duncan"}
+        else:
+            assert friends_leto == {b"duncan", b"ghanima"}
+            assert friends_paul == {b"gurney", b"duncan"}
+
+    def test_set_operations(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _sets_setup(redis_client)
         inter = redis_client.sinter("friends:leto", "friends:paul")
-        assert inter == {b"duncan"}
+        if is_decoded:
+            assert inter == {"duncan"}
+        else:
+            assert inter == {b"duncan"}
 
         union = redis_client.sunion("friends:leto", "friends:paul")
-        assert union == {b"ghanima", b"duncan", b"gurney"}
+        if is_decoded:
+            assert union == {"ghanima", "duncan", "gurney"}
+        else:
+            assert union == {b"ghanima", b"duncan", b"gurney"}
 
         diff = redis_client.sdiff("friends:leto", "friends:paul")
-        assert diff == {b"ghanima"}
+        if is_decoded:
+            assert diff == {"ghanima"}
+        else:
+            assert diff == {b"ghanima"}
 
         cardinality_leto = redis_client.scard("friends:leto")
         assert cardinality_leto == 2
@@ -130,42 +202,70 @@ class TestSets:
         assert redis_client.sismember("friends:paul", "ghanima")
 
 
+@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestHashes:
-    def test_hset(self, redis_client):
+    def test_hset(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _hash_setup(redis_client)
         user = redis_client.hgetall("user")
-        assert user == {b"name": b"foo", b"age": b"30"}
+        if is_decoded:
+            assert user == {"name": "foo", "age": "30"}
+        else:
+            assert user == {b"name": b"foo", b"age": b"30"}
 
-    def test_hash_operations(self, redis_client):
+    def test_hash_operations(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _hash_setup(redis_client)
         assert redis_client.hexists("user", "name")
         assert redis_client.hexists("user", "age")
 
         keys = redis_client.hkeys("user")
-        assert keys == [b"name", b"age"]
+        if is_decoded:
+            assert keys == ["name", "age"]
+        else:
+            assert keys == [b"name", b"age"]
 
         len = redis_client.hlen("user")
         assert len == 2
 
         vals = redis_client.hvals("user")
-        assert vals == [b"foo", b"30"]
+        if is_decoded:
+            assert vals == ["foo", "30"]
+        else:
+            assert vals == [b"foo", b"30"]
 
 
+@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestLists:
-    def test_lset(self, redis_client):
+    def test_lset(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _list_setup(redis_client)
         items = redis_client.lrange("dbs", 0, 4)
-        assert items == [b"mysql_lite", b"mysql", b"postgres", b"redis", b"mongo"]
+        if is_decoded:
+            assert items == ["mysql_lite", "mysql", "postgres", "redis", "mongo"]
+        else:
+            assert items == [b"mysql_lite", b"mysql", b"postgres", b"redis", b"mongo"]
 
-    def test_list_operations(self, redis_client):
+    def test_list_operations(self, redis, is_decoded, request):
+        redis_client = request.getfixturevalue(redis)
+
         _list_setup(redis_client)
         assert redis_client.llen("dbs") == 5
-        assert redis_client.lindex("dbs", 1) == b"mysql"
-        assert redis_client.lpop("dbs") == b"mysql_lite"
+        assert redis_client.lindex("dbs", 1) == ("mysql" if is_decoded else b"mysql")
+        assert redis_client.lpop("dbs") == (
+            "mysql_lite" if is_decoded else b"mysql_lite"
+        )
 
         redis_client.rpush("dbs", "RabbitMQ")
-        assert redis_client.rpop("dbs") == b"RabbitMQ"
+        assert redis_client.rpop("dbs") == ("RabbitMQ" if is_decoded else b"RabbitMQ")
 
         redis_client.ltrim("dbs", 1, -1)
         rest = redis_client.lrange("dbs", 0, -1)
-        assert rest == [b"postgres", b"redis", b"mongo"]
+        assert rest == (
+            ["postgres", "redis", "mongo"]
+            if is_decoded
+            else [b"postgres", b"redis", b"mongo"]
+        )

--- a/tests/fixture/test_redis.py
+++ b/tests/fixture/test_redis.py
@@ -1,12 +1,8 @@
-import pytest
-
 from pytest_mock_resources import create_redis_fixture
 from pytest_mock_resources.compat import redis
 
 redis_client = create_redis_fixture()
 redis_client_decode = create_redis_fixture(decode_responses=True)
-
-client_parameters = [("redis_client", False), ("redis_client_decode", True)]
 
 
 def _sets_setup(redis_client):
@@ -47,151 +43,142 @@ class TestGeneric:
         assert value == "bar"
 
 
-@pytest.mark.parametrize("redis,is_decoded", client_parameters)
-class TestStrings:
-    def test_set(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
-        redis_client.set("foo", "bar")
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
+class TestStringsDecoded:
+    def test_set(self, redis_client_decode):
+        redis_client_decode.set("foo", "bar")
+        value = redis_client_decode.get("foo")
         assert value == "bar"
 
-    def test_append(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
-        redis_client.set("foo", "bar")
-        redis_client.append("foo", "baz")
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
+    def test_append(self, redis_client_decode):
+        redis_client_decode.set("foo", "bar")
+        redis_client_decode.append("foo", "baz")
+        value = redis_client_decode.get("foo")
         assert value == "barbaz"
 
-    def test_int_operations(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
+    def test_int_operations(self, redis_client_decode):
+        redis_client_decode.set("foo", 1)
+        redis_client_decode.incr("foo")
+        value = int(redis_client_decode.get("foo"))
+        assert value == 2
 
-        redis_client.set("foo", 1)
-        redis_client.incr("foo")
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert int(value) == 2
+        redis_client_decode.decr("foo")
+        value = int(redis_client_decode.get("foo"))
+        assert value == 1
 
-        redis_client.decr("foo")
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert int(value) == 1
+        redis_client_decode.incrby("foo", 4)
+        value = int(redis_client_decode.get("foo"))
+        assert value == 5
 
-        redis_client.incrby("foo", 4)
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert int(value) == 5
+        redis_client_decode.decrby("foo", 3)
+        value = int(redis_client_decode.get("foo"))
+        assert value == 2
 
-        redis_client.decrby("foo", 3)
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
+    def test_float_operations(self, redis_client_decode):
+        redis_client_decode.set("foo", 1.2)
+        value = float(redis_client_decode.get("foo"))
+        assert value == 1.2
 
-        assert int(value) == 2
+        redis_client_decode.incrbyfloat("foo", 4.1)
+        value = float(redis_client_decode.get("foo"))
+        assert value == 5.3
 
-    def test_float_operations(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
+        redis_client_decode.incrbyfloat("foo", -3.1)
+        value = float(redis_client_decode.get("foo"))
+        assert value == 2.2
 
-        redis_client.set("foo", 1.2)
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert float(value) == 1.2
-
-        redis_client.incrbyfloat("foo", 4.1)
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert float(value) == 5.3
-
-        redis_client.incrbyfloat("foo", -3.1)
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert float(value) == 2.2
-
-    def test_multiple_keys(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_multiple_keys(self, redis_client_decode):
         test_mapping = {"foo": "bar", "baz": 1, "flo": 1.2}
-        redis_client.mset(test_mapping)
+        redis_client_decode.mset(test_mapping)
+        assert redis_client_decode.get("foo") == "bar"
+        assert int(redis_client_decode.get("baz")) == 1
+        assert float(redis_client_decode.get("flo")) == 1.2
 
-        value = redis_client.get("foo")
-        if not is_decoded:
-            value = value.decode("utf-8")
+    def test_querries(self, redis_client_decode):
+        test_mapping = {"foo1": "bar1", "foo2": "bar2", "flo": "flo"}
+        redis_client_decode.mset(test_mapping)
+        foo_keys = redis_client_decode.keys("foo*")
+        assert "foo1" in foo_keys
+        assert "foo2" in foo_keys
+        assert "flo" not in foo_keys
+
+
+class TestStrings:
+    def test_set(self, redis_client):
+        redis_client.set("foo", "bar")
+        value = redis_client.get("foo").decode("utf-8")
         assert value == "bar"
 
-        value = redis_client.get("baz")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert int(value) == 1
+    def test_append(self, redis_client):
+        redis_client.set("foo", "bar")
+        redis_client.append("foo", "baz")
+        value = redis_client.get("foo").decode("utf-8")
+        assert value == "barbaz"
 
-        value = redis_client.get("flo")
-        if not is_decoded:
-            value = value.decode("utf-8")
-        assert float(value) == 1.2
+    def test_int_operations(self, redis_client):
+        redis_client.set("foo", 1)
+        redis_client.incr("foo")
+        value = int(redis_client.get("foo").decode("utf-8"))
+        assert value == 2
 
-    def test_querries(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
+        redis_client.decr("foo")
+        value = int(redis_client.get("foo").decode("utf-8"))
+        assert value == 1
 
+        redis_client.incrby("foo", 4)
+        value = int(redis_client.get("foo").decode("utf-8"))
+        assert value == 5
+
+        redis_client.decrby("foo", 3)
+        value = int(redis_client.get("foo").decode("utf-8"))
+        assert value == 2
+
+    def test_float_operations(self, redis_client):
+        redis_client.set("foo", 1.2)
+        value = float(redis_client.get("foo").decode("utf-8"))
+        assert value == 1.2
+
+        redis_client.incrbyfloat("foo", 4.1)
+        value = float(redis_client.get("foo").decode("utf-8"))
+        assert value == 5.3
+
+        redis_client.incrbyfloat("foo", -3.1)
+        value = float(redis_client.get("foo").decode("utf-8"))
+        assert value == 2.2
+
+    def test_multiple_keys(self, redis_client):
+        test_mapping = {"foo": "bar", "baz": 1, "flo": 1.2}
+        redis_client.mset(test_mapping)
+        assert redis_client.get("foo").decode("utf-8") == "bar"
+        assert int(redis_client.get("baz").decode("utf-8")) == 1
+        assert float(redis_client.get("flo").decode("utf-8")) == 1.2
+
+    def test_querries(self, redis_client):
         test_mapping = {"foo1": "bar1", "foo2": "bar2", "flo": "flo"}
         redis_client.mset(test_mapping)
         foo_keys = redis_client.keys("foo*")
-        if is_decoded:
-            assert "foo1" in foo_keys
-            assert "foo2" in foo_keys
-            assert "flo" not in foo_keys
-        else:
-            assert b"foo1" in foo_keys
-            assert b"foo2" in foo_keys
-            assert b"flo" not in foo_keys
+        assert b"foo1" in foo_keys
+        assert b"foo2" in foo_keys
+        assert b"flo" not in foo_keys
 
 
-@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestSets:
-    def test_sadd(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_sadd(self, redis_client):
         _sets_setup(redis_client)
         friends_leto = redis_client.smembers("friends:leto")
         friends_paul = redis_client.smembers("friends:paul")
+        assert friends_leto == {b"duncan", b"ghanima"}
+        assert friends_paul == {b"gurney", b"duncan"}
 
-        if is_decoded:
-            assert friends_leto == {"duncan", "ghanima"}
-            assert friends_paul == {"gurney", "duncan"}
-        else:
-            assert friends_leto == {b"duncan", b"ghanima"}
-            assert friends_paul == {b"gurney", b"duncan"}
-
-    def test_set_operations(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_set_operations(self, redis_client):
         _sets_setup(redis_client)
         inter = redis_client.sinter("friends:leto", "friends:paul")
-        if is_decoded:
-            assert inter == {"duncan"}
-        else:
-            assert inter == {b"duncan"}
+        assert inter == {b"duncan"}
 
         union = redis_client.sunion("friends:leto", "friends:paul")
-        if is_decoded:
-            assert union == {"ghanima", "duncan", "gurney"}
-        else:
-            assert union == {b"ghanima", b"duncan", b"gurney"}
+        assert union == {b"ghanima", b"duncan", b"gurney"}
 
         diff = redis_client.sdiff("friends:leto", "friends:paul")
-        if is_decoded:
-            assert diff == {"ghanima"}
-        else:
-            assert diff == {b"ghanima"}
+        assert diff == {b"ghanima"}
 
         cardinality_leto = redis_client.scard("friends:leto")
         assert cardinality_leto == 2
@@ -203,66 +190,42 @@ class TestSets:
         assert redis_client.sismember("friends:paul", "ghanima")
 
 
-@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestHashes:
-    def test_hset(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_hset(self, redis_client):
         _hash_setup(redis_client)
         user = redis_client.hgetall("user")
-        if is_decoded:
-            assert user == {"name": "foo", "age": "30"}
-        else:
-            assert user == {b"name": b"foo", b"age": b"30"}
+        assert user == {b"name": b"foo", b"age": b"30"}
 
-    def test_hash_operations(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_hash_operations(self, redis_client):
         _hash_setup(redis_client)
         assert redis_client.hexists("user", "name")
         assert redis_client.hexists("user", "age")
 
         keys = redis_client.hkeys("user")
-        if is_decoded:
-            assert keys == ["name", "age"]
-        else:
-            assert keys == [b"name", b"age"]
+        assert keys == [b"name", b"age"]
 
         len = redis_client.hlen("user")
         assert len == 2
 
         vals = redis_client.hvals("user")
-        if is_decoded:
-            assert vals == ["foo", "30"]
-        else:
-            assert vals == [b"foo", b"30"]
+        assert vals == [b"foo", b"30"]
 
 
-@pytest.mark.parametrize("redis,is_decoded", client_parameters)
 class TestLists:
-    def test_lset(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_lset(self, redis_client):
         _list_setup(redis_client)
         items = redis_client.lrange("dbs", 0, 4)
-        if is_decoded:
-            assert items == ["mysql_lite", "mysql", "postgres", "redis", "mongo"]
-        else:
-            assert items == [b"mysql_lite", b"mysql", b"postgres", b"redis", b"mongo"]
+        assert items == [b"mysql_lite", b"mysql", b"postgres", b"redis", b"mongo"]
 
-    def test_list_operations(self, redis, is_decoded, request):
-        redis_client = request.getfixturevalue(redis)
-
+    def test_list_operations(self, redis_client):
         _list_setup(redis_client)
         assert redis_client.llen("dbs") == 5
-        assert redis_client.lindex("dbs", 1) == ("mysql" if is_decoded else b"mysql")
-        assert redis_client.lpop("dbs") == ("mysql_lite" if is_decoded else b"mysql_lite")
+        assert redis_client.lindex("dbs", 1) == b"mysql"
+        assert redis_client.lpop("dbs") == b"mysql_lite"
 
         redis_client.rpush("dbs", "RabbitMQ")
-        assert redis_client.rpop("dbs") == ("RabbitMQ" if is_decoded else b"RabbitMQ")
+        assert redis_client.rpop("dbs") == b"RabbitMQ"
 
         redis_client.ltrim("dbs", 1, -1)
         rest = redis_client.lrange("dbs", 0, -1)
-        assert rest == (
-            ["postgres", "redis", "mongo"] if is_decoded else [b"postgres", b"redis", b"mongo"]
-        )
+        assert rest == [b"postgres", b"redis", b"mongo"]


### PR DESCRIPTION
For the redis client, the user might prefer to use the decoded response. There's no way to pass kwargs or similar, and I thought this might be reasonable.

For most of my usecases, I'm setting that parameter and would like to expect the same from the fixture.