### PR TITLE
pass container args to docker; add support for mongo transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,27 +13,27 @@ install:
 
 ## Test
 test-base:
-	SQLALCHEMY_WARN_20=1 coverage run -a -m \
+	SQLALCHEMY_WARN_20=1 poetry run coverage run -a -m \
 		pytest src tests -vv \
 		-m 'not postgres and not redshift and not mongo and not redis and not mysql and not moto'
 
 test-parallel:
-	SQLALCHEMY_WARN_20=1 coverage run -m pytest -n 4 src tests -vv --pmr-multiprocess-safe
+	SQLALCHEMY_WARN_20=1 poetry run coverage run -m pytest -n 4 src tests -vv --pmr-multiprocess-safe
 
 test: test-parallel
-	SQLALCHEMY_WARN_20=1 coverage run -a -m pytest src tests -vv
-	coverage report
-	coverage xml
+	SQLALCHEMY_WARN_20=1 poetry run coverage run -a -m pytest src tests -vv
+	poetry run coverage report
+	poetry run coverage xml
 
 ## Lint
 lint:
-	ruff --fix src tests || exit 1
-	ruff format -q src tests || exit 1
-	mypy src tests --show-error-codes || exit 1
+	poetry run ruff --fix src tests || exit 1
+	poetry run ruff format -q src tests || exit 1
+	poetry run mypy src tests --show-error-codes || exit 1
 
 format:
-	ruff src tests --fix
-	ruff format src tests
+	poetry run ruff src tests --fix
+	poetry run ruff format src tests
 
 ## Build
 build-package:
@@ -47,3 +47,10 @@ build: build-package
 
 publish: build
 	poetry publish -u __token__ -p '${PYPI_PASSWORD}' --no-interaction
+
+.PHONY: prerelease
+prerelease:
+	poetry version prerelease
+	git add pyproject.toml
+	git commit -m "Release version $$(poetry version --short)"
+	git tag $$(poetry version --short)

--- a/src/pytest_mock_resources/config.py
+++ b/src/pytest_mock_resources/config.py
@@ -117,7 +117,7 @@ class DockerContainerConfig:
 
     @fallback
     def container_args(self):
-        return ()
+        return []
 
     def ports(self):
         return {}

--- a/src/pytest_mock_resources/container/base.py
+++ b/src/pytest_mock_resources/container/base.py
@@ -8,6 +8,7 @@ import time
 import types
 from typing import Awaitable, Callable, TYPE_CHECKING, TypeVar
 
+from pytest_mock_resources.config import DockerContainerConfig
 from pytest_mock_resources.hooks import (
     get_docker_client,
     get_pytest_flag,
@@ -129,7 +130,11 @@ def get_container(pytestconfig, config, *, retries=DEFAULT_RETRIES, interval=DEF
 
 
 def wait_for_container(
-    docker: DockerClient, config, *, retries=DEFAULT_RETRIES, interval=DEFAULT_INTERVAL
+    docker: DockerClient,
+    config: DockerContainerConfig,
+    *,
+    retries=DEFAULT_RETRIES,
+    interval=DEFAULT_INTERVAL,
 ):
     """Wait for evidence that the container is up and healthy.
 
@@ -158,7 +163,9 @@ def wait_for_container(
     except ContainerCheckFailed:
         # In the event it doesn't exist, we attempt to start the container
         try:
-            container = docker.run(*run_args, **run_kwargs, detach=True, remove=True)
+            container = docker.run(
+                *run_args, **run_kwargs, command=config.container_args, detach=True, remove=True
+            )
         except DockerException as e:
             container = None
             # This sometimes happens if multiple container fixtures race for the first

--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -23,7 +23,14 @@ class MongoConfig(DockerContainerConfig):
 
     name = "mongo"
 
-    _fields: ClassVar[Iterable] = {"image", "host", "port", "ci_port", "root_database"}
+    _fields: ClassVar[Iterable] = {
+        "image",
+        "host",
+        "port",
+        "ci_port",
+        "root_database",
+        "container_args",
+    }
     _fields_defaults: ClassVar[dict] = {
         "image": "mongo:3.6",
         "port": 28017,

--- a/src/pytest_mock_resources/fixture/redis.py
+++ b/src/pytest_mock_resources/fixture/redis.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_mock_resources.compat import redis
 from pytest_mock_resources.container.base import get_container
 from pytest_mock_resources.container.redis import RedisConfig


### PR DESCRIPTION
in order to use mongodb transactions, the servers have to be deployed as a replica set or sharded cluster. This requires passing in additional options when docker starts. This change makes it so

Replication is turned on by passing in `--replSet` as a container argument. Usage would look something like this
```python
@pytest.fixture(scope="session", autouse=True)
def pmr_mongo_config():
    return MongoConfig(
        image="mongo:7",
        root_database=$MONGO_APP_DB,
        port=27017,
        container_args=["--replSet", "rs0", "--bind_ip_all", "--oplogSize", "128"],
    )
```