### PR TITLE
fix: Lower the connection timeout on pymongo client to reduce startup lag.

### DIFF
--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -40,10 +40,10 @@ class MongoConfig(DockerContainerConfig):
 
     def check_fn(self):
         try:
-            client = pymongo.MongoClient(self.host, self.port)
+            client = pymongo.MongoClient(self.host, self.port, timeoutMS=500)
             db = client[self.root_database]
             db.command("ismaster")
-        except pymongo.errors.ConnectionFailure:
+        except (pymongo.errors.ConnectionFailure, pymongo.errors.PyMongoError):
             raise ContainerCheckFailed(
                 f"Unable to connect to a presumed MongoDB test container via given config: {self}"
             )

--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -40,7 +40,7 @@ class MongoConfig(DockerContainerConfig):
 
     def check_fn(self):
         try:
-            client = pymongo.MongoClient(self.host, self.port, timeoutMS=500)
+            client = pymongo.MongoClient(self.host, self.port, timeoutMS=1000)
             db = client[self.root_database]
             db.command("ismaster")
         except (pymongo.errors.ConnectionFailure, pymongo.errors.PyMongoError):

--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -43,7 +43,7 @@ class MongoConfig(DockerContainerConfig):
             client = pymongo.MongoClient(self.host, self.port, timeoutMS=1000)
             db = client[self.root_database]
             db.command("ismaster")
-        except (pymongo.errors.ConnectionFailure, pymongo.errors.PyMongoError):
+        except pymongo.errors.PyMongoError:
             raise ContainerCheckFailed(
                 f"Unable to connect to a presumed MongoDB test container via given config: {self}"
             )


### PR DESCRIPTION
The python MongoClient has a default timeout of 20 seconds. If the container isn't up by the time it does the first alive check, it will take 20 seconds to timeout before checking again, leading to painfully long startup times.

Adding a more reasonable timeout to the check_fn mitigates this issue.

Addresses #220.