### PR TITLE
fix: pmr --stop subcommand.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-mock-resources"
-version = "2.12.3"
+version = "2.12.4"
 description = "A pytest plugin for easily instantiating reproducible mock resources."
 authors = [
     "Omar Khan <oakhan3@gmail.com>",

--- a/src/pytest_mock_resources/cli.py
+++ b/src/pytest_mock_resources/cli.py
@@ -81,7 +81,7 @@ def execute(fixture: str, pytestconfig: StubPytestConfig, start=True, stop=False
             pass
 
     if stop:
-        docker = get_docker_client(config)
+        docker = get_docker_client(pytestconfig)
 
         assert config.port
         name = container_name(fixture, int(config.port))


### PR DESCRIPTION
Fixes https://github.com/schireson/pytest-mock-resources/issues/228

Unfortunately our CLI and hook code is fairly untyped and the CLI code is abusing the pytest hook structures as it is, so this got missed. but there no quick fix for that, so this minimal pr should at least address the problem.