### PR TITLE
feat: handle MEDIAN and LISTAGG functions for Redshift

### DIFF
--- a/src/pytest_mock_resources/fixture/redshift/udf.py
+++ b/src/pytest_mock_resources/fixture/redshift/udf.py
@@ -116,6 +116,103 @@ convert_timezone_no_source = create_udf(
     language=UdfLanguage.SQL.value,
 )
 
+# median is implemented by collecting inputs into an array via array_append
+# and, in the final function, computing percentile_cont(0.5) over the
+# unnested array. this matches redshift's MEDIAN semantics, which is
+# equivalent to percentile_cont(0.5) within group (order by col).
+_median_final_numeric = text(
+    """
+    CREATE FUNCTION public._median_final(NUMERIC[]) RETURNS NUMERIC AS $$
+        SELECT (percentile_cont(0.5)
+                WITHIN GROUP (ORDER BY v::double precision))::NUMERIC
+        FROM unnest($1) AS v
+        WHERE v IS NOT NULL;
+    $$ LANGUAGE SQL IMMUTABLE;
+    """
+)
+
+_median_final_double = text(
+    """
+    CREATE FUNCTION public._median_final(DOUBLE PRECISION[]) RETURNS DOUBLE PRECISION AS $$
+        SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY v)
+        FROM unnest($1) AS v
+        WHERE v IS NOT NULL;
+    $$ LANGUAGE SQL IMMUTABLE;
+    """
+)
+
+median_numeric = text(
+    """
+    CREATE AGGREGATE public.median(NUMERIC) (
+        SFUNC = array_append,
+        STYPE = NUMERIC[],
+        FINALFUNC = public._median_final,
+        INITCOND = '{}'
+    );
+    """
+)
+
+median_double = text(
+    """
+    CREATE AGGREGATE public.median(DOUBLE PRECISION) (
+        SFUNC = array_append,
+        STYPE = DOUBLE PRECISION[],
+        FINALFUNC = public._median_final,
+        INITCOND = '{}'
+    );
+    """
+)
+
+# listagg concatenates non-null values into a single string with a
+# delimiter. the two-argument state function coerces each input to text
+# and appends it with the separator; the final function trims the leading
+# separator. redshift also supports LISTAGG(col) without a delimiter,
+# which defaults to an empty string between values.
+_listagg_sfunc = text(
+    """
+    CREATE FUNCTION public._listagg_sfunc(state TEXT, value TEXT, delimiter TEXT)
+    RETURNS TEXT AS $$
+        SELECT CASE
+            WHEN value IS NULL THEN state
+            WHEN state IS NULL OR state = '' THEN value
+            ELSE state || delimiter || value
+        END;
+    $$ LANGUAGE SQL IMMUTABLE;
+    """
+)
+
+_listagg_sfunc_no_delim = text(
+    """
+    CREATE FUNCTION public._listagg_sfunc_no_delim(state TEXT, value TEXT)
+    RETURNS TEXT AS $$
+        SELECT CASE
+            WHEN value IS NULL THEN state
+            ELSE COALESCE(state, '') || value
+        END;
+    $$ LANGUAGE SQL IMMUTABLE;
+    """
+)
+
+listagg_text_delim = text(
+    """
+    CREATE AGGREGATE public.listagg(TEXT, TEXT) (
+        SFUNC = public._listagg_sfunc,
+        STYPE = TEXT,
+        INITCOND = ''
+    );
+    """
+)
+
+listagg_text = text(
+    """
+    CREATE AGGREGATE public.listagg(TEXT) (
+        SFUNC = public._listagg_sfunc_no_delim,
+        STYPE = TEXT,
+        INITCOND = ''
+    );
+    """
+)
+
 
 datediff_kwargs = {
     "returns": "BIGINT",
@@ -223,4 +320,12 @@ REDSHIFT_UDFS = Statements(
     len_varchar,
     convert_timezone,
     convert_timezone_no_source,
+    _median_final_numeric,
+    _median_final_double,
+    median_numeric,
+    median_double,
+    _listagg_sfunc,
+    _listagg_sfunc_no_delim,
+    listagg_text_delim,
+    listagg_text,
 )

--- a/tests/fixture/redshift/test_udf.py
+++ b/tests/fixture/redshift/test_udf.py
@@ -281,3 +281,99 @@ class TestUdf:
             result = conn.execute(text(f"SELECT CONVERT_TIMEZONE('{to}', '{date_}')"))
             result = result.fetchone()
             assert result[0] == expected
+
+    def test_median_odd_count(self, redshift):
+        # odd number of values: the middle value is returned.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_median (v NUMERIC)"))
+            conn.execute(text("INSERT INTO t_median VALUES (1), (2), (3), (4), (5)"))
+            result = conn.execute(text("SELECT MEDIAN(v) FROM t_median")).fetchone()
+            assert result[0] == 3
+
+    def test_median_even_count(self, redshift):
+        # even number of values: the average of the two middle values.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_median_even (v NUMERIC)"))
+            conn.execute(text("INSERT INTO t_median_even VALUES (1), (2), (3), (4)"))
+            result = conn.execute(text("SELECT MEDIAN(v) FROM t_median_even")).fetchone()
+            assert result[0] == 2.5
+
+    def test_median_ignores_nulls(self, redshift):
+        # null values must be excluded from the computation.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_median_nulls (v NUMERIC)"))
+            conn.execute(text("INSERT INTO t_median_nulls VALUES (1), (NULL), (3), (NULL), (5)"))
+            result = conn.execute(text("SELECT MEDIAN(v) FROM t_median_nulls")).fetchone()
+            assert result[0] == 3
+
+    def test_median_grouped(self, redshift):
+        # median per group should work like any aggregate.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_median_grp (g TEXT, v NUMERIC)"))
+            conn.execute(
+                text(
+                    "INSERT INTO t_median_grp VALUES "
+                    "('a', 1), ('a', 3), ('a', 5), ('b', 10), ('b', 20)"
+                )
+            )
+            result = conn.execute(
+                text("SELECT g, MEDIAN(v) FROM t_median_grp GROUP BY g ORDER BY g")
+            ).fetchall()
+            assert result == [("a", 3), ("b", 15)]
+
+    def test_median_double_precision(self, redshift):
+        # the double precision overload should work independently.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_median_dp (v DOUBLE PRECISION)"))
+            conn.execute(text("INSERT INTO t_median_dp VALUES (1.5), (2.5), (3.5)"))
+            result = conn.execute(text("SELECT MEDIAN(v) FROM t_median_dp")).fetchone()
+            assert result[0] == 2.5
+
+    def test_listagg_with_delimiter(self, redshift):
+        # basic concatenation with a delimiter argument.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_listagg (v TEXT)"))
+            conn.execute(text("INSERT INTO t_listagg VALUES ('a'), ('b'), ('c')"))
+            result = conn.execute(
+                text("SELECT LISTAGG(v, ',') FROM (SELECT v FROM t_listagg ORDER BY v) s")
+            ).fetchone()
+            assert result[0] == "a,b,c"
+
+    def test_listagg_no_delimiter(self, redshift):
+        # redshift supports LISTAGG(col) which concatenates with no separator.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_listagg_nd (v TEXT)"))
+            conn.execute(text("INSERT INTO t_listagg_nd VALUES ('x'), ('y'), ('z')"))
+            result = conn.execute(
+                text("SELECT LISTAGG(v) FROM (SELECT v FROM t_listagg_nd ORDER BY v) s")
+            ).fetchone()
+            assert result[0] == "xyz"
+
+    def test_listagg_ignores_nulls(self, redshift):
+        # null values should be skipped entirely, not produce empty segments.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_listagg_nulls (v TEXT)"))
+            conn.execute(text("INSERT INTO t_listagg_nulls VALUES ('a'), (NULL), ('b'), (NULL)"))
+            result = conn.execute(
+                text("SELECT LISTAGG(v, '|') FROM (SELECT v FROM t_listagg_nulls ORDER BY v) s")
+            ).fetchone()
+            assert result[0] == "a|b"
+
+    def test_listagg_grouped(self, redshift):
+        # listagg per group should work like any aggregate.
+        with redshift.connect() as conn:
+            conn.execute(text("CREATE TEMP TABLE t_listagg_grp (g TEXT, v TEXT)"))
+            conn.execute(
+                text(
+                    "INSERT INTO t_listagg_grp VALUES "
+                    "('a', 'x'), ('a', 'y'), ('b', 'p'), ('b', 'q')"
+                )
+            )
+            result = conn.execute(
+                text(
+                    "SELECT g, LISTAGG(v, ',') "
+                    "FROM (SELECT g, v FROM t_listagg_grp ORDER BY g, v) s "
+                    "GROUP BY g ORDER BY g"
+                )
+            ).fetchall()
+            assert result == [("a", "x,y"), ("b", "p,q")]


### PR DESCRIPTION
Closes the remaining `MEDIAN` and `LISTAGG` checkboxes on #213.

## What
Adds two Redshift aggregate UDFs that previously raised `function does not exist` errors against the mock fixture:

- **`MEDIAN(col)`** — matches Redshift semantics (average of the two middle values on even-count input, NULLs ignored). Registered for `NUMERIC` and `DOUBLE PRECISION`.
- **`LISTAGG(col[, delimiter])`** — concatenates non-NULL values, with or without a delimiter argument.

## How
The [#213 thread](https://github.com/schireson/pytest-mock-resources/issues/213) flagged that Redshift does not allow SQL UDFs for aggregate operations, which is why these two were not delivered in #212 / #214. This PR works around that by using native Postgres `CREATE AGGREGATE`, which is available because the Redshift fixture runs on top of a Postgres container.

- `MEDIAN` collects inputs into an array via `array_append` as the state function, then the final function runs `percentile_cont(0.5) WITHIN GROUP` over `unnest`, casting back to `NUMERIC` for that overload (`percentile_cont` always returns `double precision`).
- `LISTAGG` uses a plain SQL state function that skips NULLs and appends with the supplied delimiter (or empty string for the single-arg form).

## Tests
9 new tests in `tests/fixture/redshift/test_udf.py` covering:
- MEDIAN: odd/even count, NULL handling, GROUP BY, DOUBLE PRECISION overload
- LISTAGG: with delimiter, without delimiter, NULL handling, GROUP BY

All 65 tests in `test_udf.py` pass locally (56 existing + 9 new). `ruff` and `ruff format` both clean.