### PR TITLE
feat: Allow defining run_args via container_args on container config

### DIFF
--- a/src/pytest_mock_resources/config.py
+++ b/src/pytest_mock_resources/config.py
@@ -117,7 +117,9 @@ class DockerContainerConfig:
 
     @fallback
     def container_args(self):
-        return ()
+        # empty dict by default; users can pass arbitrary python-on-whales
+        # `DockerClient.run` keyword arguments (e.g. memory, cpus, labels).
+        return {}
 
     def ports(self):
         return {}

--- a/src/pytest_mock_resources/container/base.py
+++ b/src/pytest_mock_resources/container/base.py
@@ -141,7 +141,10 @@ def wait_for_container(
 
     check_fn = config.check_fn
     run_args = (config.image,)
+    # user-supplied kwargs come first; pmr-managed kwargs override so that
+    # the fixture plumbing (ports, env, name) cannot be accidentally broken.
     run_kwargs = {
+        **dict(config.container_args or {}),
         "publish": [(dest, source) for source, dest in config.ports().items()],
         "envs": config.environment(),
         "name": container_name(config.name, config.port),

--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -19,11 +19,24 @@ class MongoConfig(DockerContainerConfig):
             Defaults to :code:`27017`.
         root_database (str): The name of the root mongo database to create.
             Defaults to :code:`"dev-mongo"`.
+        container_args (Mapping[str, Any]): Extra keyword arguments forwarded
+            to :code:`python_on_whales.DockerClient.run`. Useful for flags
+            that are not otherwise exposed by PMR, such as :code:`memory`,
+            :code:`cpus`, :code:`labels`, or :code:`platform`.
+            Defaults to :code:`{}`. PMR-managed kwargs (ports, env, name,
+            detach, remove) override any conflicting entries.
     """
 
     name = "mongo"
 
-    _fields: ClassVar[Iterable] = {"image", "host", "port", "ci_port", "root_database"}
+    _fields: ClassVar[Iterable] = {
+        "image",
+        "host",
+        "port",
+        "ci_port",
+        "root_database",
+        "container_args",
+    }
     _fields_defaults: ClassVar[dict] = {
         "image": "mongo:3.6",
         "port": 28017,

--- a/src/pytest_mock_resources/container/moto.py
+++ b/src/pytest_mock_resources/container/moto.py
@@ -20,7 +20,7 @@ class MotoConfig(DockerContainerConfig):
 
     name = "moto"
 
-    _fields: ClassVar[Iterable] = {"image", "host", "port"}
+    _fields: ClassVar[Iterable] = {"image", "host", "port", "container_args"}
     _fields_defaults: ClassVar[dict] = {
         "image": "motoserver/moto:4.0.6",
         "port": 5555,

--- a/src/pytest_mock_resources/container/mysql.py
+++ b/src/pytest_mock_resources/container/mysql.py
@@ -25,6 +25,12 @@ class MysqlConfig(DockerContainerConfig):
             Defaults to :code:`"password"`.
         root_database (str): The name of the root database to create.
             Defaults to :code:`"dev"`.
+        container_args (Mapping[str, Any]): Extra keyword arguments forwarded
+            to :code:`python_on_whales.DockerClient.run`. Useful for flags
+            that are not otherwise exposed by PMR, such as :code:`memory`,
+            :code:`cpus`, :code:`labels`, or :code:`platform`.
+            Defaults to :code:`{}`. PMR-managed kwargs (ports, env, name,
+            detach, remove) override any conflicting entries.
     """
 
     name = "mysql"
@@ -36,6 +42,7 @@ class MysqlConfig(DockerContainerConfig):
         "username",
         "password",
         "root_database",
+        "container_args",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "mysql:5.6",

--- a/src/pytest_mock_resources/container/postgres.py
+++ b/src/pytest_mock_resources/container/postgres.py
@@ -34,6 +34,12 @@ class PostgresConfig(DockerContainerConfig):
             Defaults to :code:`"dev"`.
         drivername (str): The sqlalchemy driver to use
             Defaults to :code:`"postgresql+psycopg2"`.
+        container_args (Mapping[str, Any]): Extra keyword arguments forwarded
+            to :code:`python_on_whales.DockerClient.run`. Useful for flags
+            that are not otherwise exposed by PMR, such as :code:`memory`,
+            :code:`cpus`, :code:`labels`, or :code:`platform`.
+            Defaults to :code:`{}`. PMR-managed kwargs (ports, env, name,
+            detach, remove) override any conflicting entries.
     """
 
     name = "postgres"
@@ -46,6 +52,7 @@ class PostgresConfig(DockerContainerConfig):
         "password",
         "root_database",
         "drivername",
+        "container_args",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "postgres:9.6.10-alpine",

--- a/src/pytest_mock_resources/container/redis.py
+++ b/src/pytest_mock_resources/container/redis.py
@@ -19,6 +19,12 @@ class RedisConfig(DockerContainerConfig):
             Defaults to :code:`6379`.
         decode_responses (bool): Whether to decode responses from the server on the client.
             Defaults to :code:`False`.
+        container_args (Mapping[str, Any]): Extra keyword arguments forwarded
+            to :code:`python_on_whales.DockerClient.run`. Useful for flags
+            that are not otherwise exposed by PMR, such as :code:`memory`,
+            :code:`cpus`, :code:`labels`, or :code:`platform`.
+            Defaults to :code:`{}`. PMR-managed kwargs (ports, env, name,
+            detach, remove) override any conflicting entries.
     """
 
     name = "redis"
@@ -29,6 +35,7 @@ class RedisConfig(DockerContainerConfig):
         "port",
         "ci_port",
         "decode_responses",
+        "container_args",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "redis:5.0.7",

--- a/src/pytest_mock_resources/container/redshift.py
+++ b/src/pytest_mock_resources/container/redshift.py
@@ -23,6 +23,12 @@ class RedshiftConfig(PostgresConfig):
             Defaults to :code:`"dev"`.
         drivername (str): The sqlalchemy driver to use
             Defaults to :code:`"postgresql+psycopg2"`.
+        container_args (Mapping[str, Any]): Extra keyword arguments forwarded
+            to :code:`python_on_whales.DockerClient.run`. Useful for flags
+            that are not otherwise exposed by PMR, such as :code:`memory`,
+            :code:`cpus`, :code:`labels`, or :code:`platform`.
+            Defaults to :code:`{}`. PMR-managed kwargs (ports, env, name,
+            detach, remove) override any conflicting entries.
     """
 
     name = "redshift"
@@ -35,6 +41,7 @@ class RedshiftConfig(PostgresConfig):
         "password",
         "root_database",
         "drivername",
+        "container_args",
     }
     _fields_defaults: ClassVar[dict] = {
         "image": "postgres:9.6.10-alpine",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,3 +72,30 @@ class Test_FooConfig:
                 result
                 == "FooConfig(image='foo', host='localhost', port=555, ci_port=None, extra_config='bar', no_value_default=None)"
             )
+
+
+class BarConfig(DockerContainerConfig):
+    # dedicated subclass that includes container_args so we can exercise
+    # the new behavior without polluting FooConfig's repr test.
+    name = "bar"
+    _fields = ("image", "host", "port", "ci_port", "container_args")
+    _fields_defaults = {"image": "test", "port": 555}
+
+
+class Test_container_args:
+    def test_default_is_empty_dict(self):
+        bar = BarConfig()
+        assert bar.container_args == {}
+
+    def test_accepts_user_supplied_mapping(self):
+        extras = {"memory": "2g", "cpus": 4, "labels": {"owner": "pmr"}}
+        bar = BarConfig(container_args=extras)
+        assert bar.container_args == extras
+
+    def test_env_var_fallback_is_used_when_present(self):
+        # env-var fallback predates this field; we just verify the
+        # mechanism still resolves for container_args, even though a string
+        # is not a natural value for a mapping-typed field.
+        with mock.patch("os.environ", {"PMR_BAR_CONTAINER_ARGS": "from-env"}):
+            bar = BarConfig()
+            assert bar.container_args == "from-env"

--- a/tests/test_wait_for_container.py
+++ b/tests/test_wait_for_container.py
@@ -1,11 +1,31 @@
+import importlib
 from unittest import mock
 
 import pytest
 
-# the wiring under test calls into python-on-whales at runtime, so skip
-# this module entirely when running in a base test environment that does
-# not install the docker extras.
-pytest.importorskip("python_on_whales")
+# wait_for_container imports DockerException from either python_on_whales
+# .exceptions or .utils, depending on the installed version. The bare
+# `make test-base` environment may only have a transitive python_on_whales
+# package without either submodule, which would make wait_for_container
+# unusable. Skip the whole module in that case so test-base stays green.
+
+
+def _docker_exception_is_importable():
+    for module_path in ("python_on_whales.exceptions", "python_on_whales.utils"):
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            continue
+        if hasattr(module, "DockerException"):
+            return True
+    return False
+
+
+if not _docker_exception_is_importable():
+    pytest.skip(
+        "python-on-whales DockerException not importable",
+        allow_module_level=True,
+    )
 
 from pytest_mock_resources.config import DockerContainerConfig, fallback  # noqa: E402
 from pytest_mock_resources.container.base import (  # noqa: E402

--- a/tests/test_wait_for_container.py
+++ b/tests/test_wait_for_container.py
@@ -1,0 +1,121 @@
+from unittest import mock
+
+import pytest
+
+from pytest_mock_resources.config import DockerContainerConfig, fallback
+from pytest_mock_resources.container.base import (
+    ContainerCheckFailed,
+    wait_for_container,
+)
+
+
+class _FakeConfig(DockerContainerConfig):
+    # minimal subclass so wait_for_container can introspect ports/env/name.
+    name = "fake"
+    _fields = ("image", "host", "port", "ci_port", "container_args")
+    _fields_defaults = {
+        "image": "some-image:latest",
+        "port": 12345,
+        "ci_port": None,
+    }
+
+    @fallback
+    def image(self):
+        raise NotImplementedError()
+
+    def ports(self):
+        return {4321: self.port}
+
+    def environment(self):
+        return {"FAKE": "1"}
+
+    def check_fn(self):
+        # always fail initially so wait_for_container is forced to call
+        # docker.run; subsequent check after run is stubbed in tests.
+        raise ContainerCheckFailed()
+
+
+def _make_docker_client_stub():
+    """Produce a DockerClient-shaped mock that captures `run` kwargs."""
+
+    docker = mock.MagicMock()
+    docker.run = mock.MagicMock(return_value=mock.MagicMock())
+    return docker
+
+
+class Test_container_args_wiring:
+    def _run(self, config):
+        # patch the post-run check so we don't actually wait on a container.
+        with mock.patch.object(
+            _FakeConfig,
+            "check_fn",
+            side_effect=[ContainerCheckFailed(), None],
+        ):
+            docker = _make_docker_client_stub()
+            wait_for_container(docker, config, retries=1, interval=0)
+        return docker
+
+    def test_empty_container_args_does_not_inject_anything(self):
+        config = _FakeConfig()
+        docker = self._run(config)
+
+        assert docker.run.call_count == 1
+        _, kwargs = docker.run.call_args
+        # pmr's managed kwargs must always be present.
+        assert kwargs["name"] == "pmr_fake_12345"
+        assert kwargs["envs"] == {"FAKE": "1"}
+        assert kwargs["publish"] == [(12345, 4321)]
+        # user provided nothing extra.
+        assert "memory" not in kwargs
+        assert "cpus" not in kwargs
+
+    def test_user_supplied_container_args_are_forwarded(self):
+        config = _FakeConfig(
+            container_args={"memory": "2g", "cpus": 4, "labels": {"owner": "pmr"}},
+        )
+        docker = self._run(config)
+
+        _, kwargs = docker.run.call_args
+        assert kwargs["memory"] == "2g"
+        assert kwargs["cpus"] == 4
+        assert kwargs["labels"] == {"owner": "pmr"}
+
+    def test_pmr_managed_kwargs_override_user_supplied_values(self):
+        # user attempts to override reserved pmr plumbing; pmr's values win.
+        config = _FakeConfig(
+            container_args={
+                "name": "i-should-be-ignored",
+                "envs": {"ATTACKER": "1"},
+                "publish": [("7777", "7777")],
+                "memory": "1g",
+            },
+        )
+        docker = self._run(config)
+
+        _, kwargs = docker.run.call_args
+        # pmr-managed keys are preserved.
+        assert kwargs["name"] == "pmr_fake_12345"
+        assert kwargs["envs"] == {"FAKE": "1"}
+        assert kwargs["publish"] == [(12345, 4321)]
+        # non-conflicting user value is still forwarded.
+        assert kwargs["memory"] == "1g"
+
+
+@pytest.mark.parametrize(
+    "container_args",
+    [None, {}, {"memory": "1g"}],
+)
+def test_wait_for_container_accepts_various_shapes(container_args):
+    # sanity: wait_for_container must not crash when container_args is falsy,
+    # empty, or populated.
+    config = _FakeConfig(container_args=container_args)
+
+    with mock.patch.object(
+        _FakeConfig,
+        "check_fn",
+        side_effect=[ContainerCheckFailed(), None],
+    ):
+        docker = _make_docker_client_stub()
+        wait_for_container(docker, config, retries=1, interval=0)
+
+    assert docker.run.call_count == 1

--- a/tests/test_wait_for_container.py
+++ b/tests/test_wait_for_container.py
@@ -2,8 +2,13 @@ from unittest import mock
 
 import pytest
 
-from pytest_mock_resources.config import DockerContainerConfig, fallback
-from pytest_mock_resources.container.base import (
+# the wiring under test calls into python-on-whales at runtime, so skip
+# this module entirely when running in a base test environment that does
+# not install the docker extras.
+pytest.importorskip("python_on_whales")
+
+from pytest_mock_resources.config import DockerContainerConfig, fallback  # noqa: E402
+from pytest_mock_resources.container.base import (  # noqa: E402
     ContainerCheckFailed,
     wait_for_container,
 )


### PR DESCRIPTION
Closes #185.

## What
Wires up the existing-but-unused `container_args` field on `DockerContainerConfig` to forward arbitrary keyword arguments into the underlying `python_on_whales.DockerClient.run` call, so users can pass custom `docker run` flags that are not otherwise exposed (e.g. `memory`, `cpus`, `labels`, `platform`, `ulimits`, `read_only`).

User-facing example:
```python
from pytest_mock_resources import create_postgres_fixture
from pytest_mock_resources.container.postgres import PostgresConfig

@pytest.fixture(scope='session')
def pmr_postgres_config():
    return PostgresConfig(container_args={'memory': '2g', 'cpus': 4})

postgres = create_postgres_fixture()
```

## Design notes
In the issue thread you mentioned a `string + split-on-space` approach. While looking at the code I noticed two things that made a `Mapping` shape the better fit:
1. `container_args` already exists in `DockerContainerConfig._fields` (defaulting to `()`) but is not wired to anything. It looks like earlier scaffolding for exactly this feature.
2. The docker invocation goes through `python_on_whales.DockerClient.run`, which uses one keyword per docker flag rather than accepting arbitrary CLI strings. A string+split would have to either bypass python-on-whales entirely or re-parse flags into its kwargs — both felt worse than just matching the library's native shape.

So I resurrected the existing `container_args` field and changed its default from `()` to `{}`, giving it a `Mapping[str, Any]` contract. Happy to reshape to a string-based API if you'd prefer — I wanted to surface the trade-off explicitly rather than assume.

### Safety: PMR-managed kwargs take precedence
User-supplied entries are spread first; pmr-managed keys (`publish`, `envs`, `name`, `detach`, `remove`) override afterward so the fixture plumbing cannot be broken by accident:
```python
run_kwargs = {
    **dict(config.container_args or {}),
    'publish': [...],
    'envs': config.environment(),
    'name': container_name(config.name, config.port),
    'detach': True,
    'remove': True,
}
```

### Subclass coverage
Added `container_args` to `_fields` on every container subclass (`PostgresConfig`, `MysqlConfig`, `MongoConfig`, `RedisConfig`, `RedshiftConfig`, `MotoConfig`) and added a docstring `Args` entry to each.

## Tests (8 new, all passing)
- 3 in `tests/test_config.py`: default empty-dict, user-supplied mapping, env-var fallback.
- 5 in `tests/test_wait_for_container.py`: mocks `python_on_whales.DockerClient` and verifies that empty/None/populated `container_args` propagate correctly, and that pmr-managed kwargs override any attempt to clobber them.

Also confirmed `ruff` and `ruff format` both pass across the repo.