### PR TITLE
refactor: use f-string and remove intermediate generator variable in cli.py

### DIFF
--- a/src/pytest_mock_resources/cli.py
+++ b/src/pytest_mock_resources/cli.py
@@ -57,7 +57,7 @@ def create_parser():
         metavar="Fixture",
         type=str,
         nargs="+",
-        help="Available Fixtures: {}".format(", ".join(DockerContainerConfig.subclasses)),
+        help=f"Available Fixtures: {', '.join(DockerContainerConfig.subclasses)}",
     )
     parser.add_argument(
         "--stop", action="store_true", help="Stop previously started PMR containers"
@@ -76,13 +76,11 @@ def execute(fixture: str, pytestconfig: StubPytestConfig, start=True, stop=False
     config = config_cls()
 
     if start:
-        generator = get_container(pytestconfig, config)
-        for _ in generator:
+        for _ in get_container(pytestconfig, config):
             pass
 
     if stop:
         docker = get_docker_client(pytestconfig)
-
         assert config.port
         name = container_name(fixture, int(config.port))
         try:


### PR DESCRIPTION
Wow, this is a cool repo! I made a small cleanup in `cli.py`: Replaced `.format()` with an f-string in `create_parser` for consistency with the rest of the file and removed the `generator` variable in `execute`, iterating `get_container()` directly insteadNo behavior change, output is identical. Hope this helps!