### PR TITLE
feat: strip DISTKEY/SORTKEY/DISTSTYLE clauses in raw SQL for Redshift fixture

### DIFF
--- a/src/pytest_mock_resources/patch/redshift/psycopg2.py
+++ b/src/pytest_mock_resources/patch/redshift/psycopg2.py
@@ -6,6 +6,10 @@ from sqlalchemy.sql.base import Executable
 from pytest_mock_resources.container.postgres import PostgresConfig
 from pytest_mock_resources.patch.redshift.mock_s3_copy import mock_s3_copy_command, strip
 from pytest_mock_resources.patch.redshift.mock_s3_unload import mock_s3_unload_command
+from pytest_mock_resources.patch.redshift.redshift_ddl import (
+    is_create_table,
+    strip_redshift_table_options,
+)
 
 
 @contextlib.contextmanager
@@ -38,6 +42,9 @@ def mock_psycopg2_connect(config: PostgresConfig, database: str, _connect):
         def execute(self, sql, args=None):
             if isinstance(sql, Executable):
                 return super().execute(sql, args)
+
+            if is_create_table(sql):
+                sql = strip_redshift_table_options(sql)
 
             if strip(sql).lower().startswith("copy"):
                 mock_s3_copy_command(sql, self)

--- a/src/pytest_mock_resources/patch/redshift/redshift_ddl.py
+++ b/src/pytest_mock_resources/patch/redshift/redshift_ddl.py
@@ -1,0 +1,27 @@
+"""Strip Redshift-only clauses from CREATE TABLE statements.
+
+DISTKEY, SORTKEY, and DISTSTYLE are accepted by Redshift but rejected by
+Postgres. Since the fixture is backed by Postgres, raw SQL containing them
+must have them removed before forwarding to the cursor.
+"""
+import re
+
+_DISTKEY_RE = re.compile(r"\s*DISTKEY\s*\(\s*[^)]*\)", re.IGNORECASE)
+_DISTSTYLE_RE = re.compile(r"\s*DISTSTYLE\s+(?:AUTO|EVEN|KEY|ALL)", re.IGNORECASE)
+_SORTKEY_RE = re.compile(
+    r"\s*(?:COMPOUND\s+|INTERLEAVED\s+)?SORTKEY\s*(?:AUTO|\(\s*[^)]*\))",
+    re.IGNORECASE,
+)
+_CREATE_TABLE_RE = re.compile(r"^\s*create\s+(?:temp(?:orary)?\s+)?table\b", re.IGNORECASE)
+
+
+def is_create_table(sql):
+    """Return True if the SQL starts with a CREATE TABLE statement."""
+    return bool(_CREATE_TABLE_RE.match(sql))
+
+
+def strip_redshift_table_options(sql):
+    """Remove Redshift-only DISTKEY/SORTKEY/DISTSTYLE clauses from the SQL."""
+    for pattern in (_DISTKEY_RE, _DISTSTYLE_RE, _SORTKEY_RE):
+        sql = pattern.sub("", sql)
+    return sql

--- a/src/pytest_mock_resources/patch/redshift/redshift_ddl.py
+++ b/src/pytest_mock_resources/patch/redshift/redshift_ddl.py
@@ -6,10 +6,10 @@ must have them removed before forwarding to the cursor.
 """
 import re
 
-_DISTKEY_RE = re.compile(r"\s*DISTKEY\s*\(\s*[^)]*\)", re.IGNORECASE)
-_DISTSTYLE_RE = re.compile(r"\s*DISTSTYLE\s+(?:AUTO|EVEN|KEY|ALL)", re.IGNORECASE)
+_DISTKEY_RE = re.compile(r"\s*\bDISTKEY\b\s*\(\s*[^)]*\)", re.IGNORECASE)
+_DISTSTYLE_RE = re.compile(r"\s*\bDISTSTYLE\b\s+(?:AUTO|EVEN|KEY|ALL)\b", re.IGNORECASE)
 _SORTKEY_RE = re.compile(
-    r"\s*(?:COMPOUND\s+|INTERLEAVED\s+)?SORTKEY\s*(?:AUTO|\(\s*[^)]*\))",
+    r"\s*(?:\b(?:COMPOUND|INTERLEAVED)\s+)?\bSORTKEY\b\s*(?:\bAUTO\b|\(\s*[^)]*\))",
     re.IGNORECASE,
 )
 _CREATE_TABLE_RE = re.compile(r"^\s*create\s+(?:temp(?:orary)?\s+)?table\b", re.IGNORECASE)

--- a/src/pytest_mock_resources/patch/redshift/sqlalchemy.py
+++ b/src/pytest_mock_resources/patch/redshift/sqlalchemy.py
@@ -6,6 +6,10 @@ from sqlalchemy.sql.base import Executable
 from pytest_mock_resources.compat import sqlparse
 from pytest_mock_resources.patch.redshift.mock_s3_copy import mock_s3_copy_command
 from pytest_mock_resources.patch.redshift.mock_s3_unload import mock_s3_unload_command
+from pytest_mock_resources.patch.redshift.redshift_ddl import (
+    is_create_table,
+    strip_redshift_table_options,
+)
 
 
 def register_redshift_behavior(engine):
@@ -46,6 +50,9 @@ def receive_before_cursor_execute(_, cursor, statement: str, parameters, context
     we return a no-op query to be executed by sqlalchemy for certain kinds of supported
     extra features.
     """
+    if is_create_table(statement):
+        statement = strip_redshift_table_options(statement)
+
     normalized_statement = _preprocess(statement).lower()
     if normalized_statement.startswith("unload"):
         mock_s3_unload_command(statement, cursor)

--- a/tests/fixture/redshift/test_distkey.py
+++ b/tests/fixture/redshift/test_distkey.py
@@ -1,0 +1,105 @@
+import pytest
+from sqlalchemy import text
+
+from pytest_mock_resources import create_redshift_fixture
+from pytest_mock_resources.compat import psycopg2
+from pytest_mock_resources.patch.redshift.redshift_ddl import (
+    is_create_table,
+    strip_redshift_table_options,
+)
+
+
+class TestStripRedshiftTableOptions:
+    def test_strip_distkey(self):
+        sql = "CREATE TABLE t (c INT) DISTKEY(c)"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c INT)"
+
+    def test_strip_sortkey_single_column(self):
+        sql = "CREATE TABLE t (c INT) SORTKEY(c)"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c INT)"
+
+    def test_strip_sortkey_multiple_columns(self):
+        sql = "CREATE TABLE t (c1 INT, c2 INT) SORTKEY(c1, c2)"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c1 INT, c2 INT)"
+
+    def test_strip_compound_sortkey(self):
+        sql = "CREATE TABLE t (c1 INT, c2 INT) COMPOUND SORTKEY(c1, c2)"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c1 INT, c2 INT)"
+
+    def test_strip_interleaved_sortkey(self):
+        sql = "CREATE TABLE t (c1 INT, c2 INT) INTERLEAVED SORTKEY(c1, c2)"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c1 INT, c2 INT)"
+
+    def test_strip_sortkey_auto(self):
+        sql = "CREATE TABLE t (c INT) SORTKEY AUTO"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c INT)"
+
+    @pytest.mark.parametrize("style", ["AUTO", "EVEN", "KEY", "ALL"])
+    def test_strip_diststyle(self, style):
+        sql = f"CREATE TABLE t (c INT) DISTSTYLE {style}"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c INT)"
+
+    def test_strip_distkey_and_sortkey_combined(self):
+        sql = "CREATE TABLE t (c1 INT, c2 VARCHAR(20)) DISTKEY(c1) SORTKEY(c1, c2);"
+        assert strip_redshift_table_options(sql) == "CREATE TABLE t (c1 INT, c2 VARCHAR(20));"
+
+    def test_strip_case_insensitive(self):
+        sql = "create table t (c int) distkey(c) sortkey(c)"
+        assert strip_redshift_table_options(sql) == "create table t (c int)"
+
+    def test_passthrough_when_no_redshift_clauses(self):
+        sql = "CREATE TABLE t (c INT)"
+        assert strip_redshift_table_options(sql) == sql
+
+
+class TestIsCreateTable:
+    def test_matches_create_table(self):
+        assert is_create_table("CREATE TABLE t (c INT)")
+
+    def test_matches_create_temp_table(self):
+        assert is_create_table("CREATE TEMP TABLE t (c INT)")
+
+    def test_matches_create_temporary_table(self):
+        assert is_create_table("CREATE TEMPORARY TABLE t (c INT)")
+
+    def test_matches_with_leading_whitespace(self):
+        assert is_create_table("  \n  CREATE TABLE t (c INT)")
+
+    def test_case_insensitive(self):
+        assert is_create_table("create table t (c INT)")
+
+    def test_rejects_select(self):
+        assert not is_create_table("SELECT * FROM t")
+
+    def test_rejects_insert(self):
+        assert not is_create_table("INSERT INTO t VALUES (1)")
+
+    def test_rejects_create_index(self):
+        assert not is_create_table("CREATE INDEX idx ON t (c)")
+
+
+redshift = create_redshift_fixture()
+
+
+def test_create_table_with_distkey_and_sortkey(redshift):
+    statement = (
+        "CREATE TABLE example_distkey_sortkey ("
+        " col1 INT,"
+        " col2 VARCHAR(20)"
+        ") DISTKEY(col1) SORTKEY(col1, col2);"
+    )
+    with redshift.begin() as conn:
+        conn.execute(text(statement))
+
+
+def test_create_table_with_diststyle(redshift):
+    statement = "CREATE TABLE example_diststyle (col1 INT) DISTSTYLE ALL;"
+    with redshift.begin() as conn:
+        conn.execute(text(statement))
+
+
+def test_create_table_with_distkey_via_psycopg2(redshift):
+    config = redshift.pmr_credentials.as_psycopg2_kwargs()
+    with psycopg2.connect(**config) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("CREATE TABLE example_distkey_psycopg2 (col1 INT) DISTKEY(col1);")

--- a/tests/fixture/redshift/test_distkey.py
+++ b/tests/fixture/redshift/test_distkey.py
@@ -51,6 +51,14 @@ class TestStripRedshiftTableOptions:
         sql = "CREATE TABLE t (c INT)"
         assert strip_redshift_table_options(sql) == sql
 
+    def test_does_not_match_keywords_inside_identifiers(self):
+        sql = (
+            "CREATE TABLE example_distkey_sortkey "
+            "(col1 INT, col2 VARCHAR(20)) DISTKEY(col1) SORTKEY(col1, col2);"
+        )
+        expected = "CREATE TABLE example_distkey_sortkey (col1 INT, col2 VARCHAR(20));"
+        assert strip_redshift_table_options(sql) == expected
+
 
 class TestIsCreateTable:
     def test_matches_create_table(self):


### PR DESCRIPTION
Fixes #99.

  `create_redshift_fixture` is backed by Postgres, which rejects Redshift-only
  `CREATE TABLE` clauses (`DISTKEY`, `SORTKEY`, `DISTSTYLE`) with a syntax
  error. This change strips those clauses at execution time so raw production
  SQL that contains them runs unchanged against the fixture.
  
  The approach mirrors how `COPY` and `UNLOAD` are already handled: a small
  helper inspects each statement, and both patch layers (SQLAlchemy
  `before_cursor_execute` and the psycopg2 `CustomCursor`) call it before
  forwarding to the cursor.
  
  ## What it covers

  * `DISTKEY(col)`
  * `[COMPOUND | INTERLEAVED] SORTKEY(col, ...)` and `SORTKEY AUTO`
  * `DISTSTYLE {AUTO | EVEN | KEY | ALL}`

  Stripping only runs when the statement begins with `CREATE TABLE` (incl.
  `TEMP` / `TEMPORARY`), so other SQL is untouched.

  ## Files
  
  * `src/pytest_mock_resources/patch/redshift/redshift_ddl.py` (new)
  * `src/pytest_mock_resources/patch/redshift/sqlalchemy.py` (wire in)
  * `src/pytest_mock_resources/patch/redshift/psycopg2.py` (wire in)
  * `tests/fixture/redshift/test_distkey.py` (new)

  No new dependencies. No public API changes.

  ## Test plan
  
  * [x] Unit tests for the stripping helper and the CREATE TABLE detector (21
  cases: per-clause, combined, case-insensitive, `TEMP`/`TEMPORARY`, negative
  cases for `SELECT` / `INSERT` / `CREATE INDEX`).
  * [x] Integration tests using `create_redshift_fixture`: SQLAlchemy path with
  `DISTKEY` + `SORTKEY`, SQLAlchemy path with `DISTSTYLE ALL`, and a raw
  `psycopg2` cursor path with `DISTKEY`.
  * [x] `ruff check` and `ruff format --check` clean against the pinned
  `0.1.15`.